### PR TITLE
refactor: update MCP tool names to match current API

### DIFF
--- a/claude-plugins/miro-research/commands/research.md
+++ b/claude-plugins/miro-research/commands/research.md
@@ -55,7 +55,7 @@ Organize findings into:
 Create appropriate Miro artifacts based on the data:
 
 ### Documents (for summaries and detailed findings)
-Use `miro__draft_doc_new` for:
+Use `miro__doc_create` for:
 - Research summary with key findings
 - Detailed explanations
 - Recommendations and next steps
@@ -63,7 +63,7 @@ Use `miro__draft_doc_new` for:
 Include markdown links to all sources: `[Title](URL)`
 
 ### Tables (for structured data)
-Use `miro__table_create_new` and `miro__table_sync_rows` for:
+Use `miro__table_create` and `miro__table_sync_rows` for:
 - Lists of resources/documents found
 - Comparison of options
 - Search results with metadata
@@ -71,7 +71,7 @@ Use `miro__table_create_new` and `miro__table_sync_rows` for:
 Columns should include linked titles, sources, dates, owners.
 
 ### Diagrams (for relationships and flows)
-Use `miro__draft_diagram_new` for:
+Use `miro__diagram_create` for:
 - Architecture/dependency diagrams (network)
 - Process flows (flowchart)
 - Topic exploration (mindmap)

--- a/claude-plugins/miro-solutions/skills/miro-platform/references/design-to-code.md
+++ b/claude-plugins/miro-solutions/skills/miro-platform/references/design-to-code.md
@@ -84,18 +84,14 @@ AI coding tools can:
 | `code_create_from_board` | Analyze wireframes/PRDs and generate code |
 | `code_explain_on_board` | Visualize code logic by creating diagrams |
 
-### MCP Document Types
+### MCP Context Tools
 
-When reading board context via MCP, specify the type of documentation needed:
+Use these tools to read board content via MCP:
 
-| Document Type | Use Case |
-|---------------|----------|
-| `project_summary` | High-level overview, starting point |
-| `screen_design_requirements` | UI/UX specifications per screen |
-| `screen_functional_requirements` | Feature requirements per screen |
-| `technical_specification` | Implementation details |
-| `style_guide` | Design tokens, colors, typography |
-| `prototypes` | Interactive prototype HTML/CSS |
+| Tool | Use Case |
+|------|----------|
+| `context_explore` | Discover board contents (frames, documents, prototypes, tables, diagrams) |
+| `context_get` | Get detailed content from specific items |
 
 ### Example: Claude Code Reading Miro
 
@@ -103,9 +99,9 @@ When reading board context via MCP, specify the type of documentation needed:
 User: "Generate the login component from the wireframe"
 
 Claude Code:
-1. Reads board via miro__context_get_board_docs
-2. Extracts screen_design_requirements for login frame
-3. Gets style_guide for design tokens
+1. Uses context_explore to discover board contents
+2. Identifies the login wireframe frame
+3. Uses context_get with the frame URL to extract details
 4. Generates React component matching the design
 ```
 
@@ -118,10 +114,9 @@ Claude Code:
 - Document design decisions in text elements
 
 ### For Development Teams
-- Request project_summary first to understand scope
+- Use context_explore first to understand board scope
 - Focus on specific frames rather than entire boards
-- Combine design requirements with technical specs
-- Use prototypes document type for exact styling
+- Use context_get with specific item URLs for detailed content
 
 ### For Product Teams
 - Keep PRDs close to related wireframes

--- a/claude-plugins/miro-solutions/templates/commands/export.md.tmpl
+++ b/claude-plugins/miro-solutions/templates/commands/export.md.tmpl
@@ -27,8 +27,8 @@ Parse the user's input to extract:
 
 1. If board URL is missing, ask the user for it
 2. Read board content using Miro MCP tools:
-   - `miro__board_get_items` to list items
-   - `miro__context_get_board_docs` for structured extraction
+   - `miro__board_list_items` to list items
+   - `miro__context_get` for structured extraction
    - `miro__table_list_rows` for table data
 3. Transform content to {{DATA_SOURCE}} format
 4. Push to {{DATA_SOURCE}} using its MCP

--- a/claude-plugins/miro-solutions/templates/commands/visualize.md.tmpl
+++ b/claude-plugins/miro-solutions/templates/commands/visualize.md.tmpl
@@ -29,7 +29,7 @@ Parse the user's input to extract:
 2. Fetch data from {{DATA_SOURCE}}
 3. Analyze data structure to determine best visualization (or use specified type)
 4. Generate diagram description for Miro
-5. Create diagram using `miro__draft_diagram_new`
+5. Create diagram using `miro__diagram_create`
 6. Report success with board link
 
 ## Examples

--- a/claude-plugins/miro-tasks/commands/status.md
+++ b/claude-plugins/miro-tasks/commands/status.md
@@ -1,6 +1,6 @@
 ---
 description: Show current miro-tasks plugin configuration and status
-allowed-tools: Bash(sh:*), mcp__plugin_miro_miro__board_get_items
+allowed-tools: Bash(sh:*), mcp__plugin_miro_miro__board_list_items
 ---
 
 Display the current status of the task tracking in Miro.

--- a/claude-plugins/miro/commands/browse.md
+++ b/claude-plugins/miro/commands/browse.md
@@ -27,7 +27,7 @@ Parse the user's input to extract:
 ## Workflow
 
 1. If board URL is missing, ask the user for it
-2. Call `mcp__plugin_miro_miro__board_get_items` with:
+2. Call `mcp__plugin_miro_miro__board_list_items` with:
    - `board_id`: The board URL
    - `limit`: Start with 50 items
    - `item_type`: (optional) Filter if specified

--- a/claude-plugins/miro/commands/diagram.md
+++ b/claude-plugins/miro/commands/diagram.md
@@ -27,7 +27,7 @@ Automatically detect or let the user specify:
 1. If board URL is missing, ask the user for it
 2. If description is missing or unclear, ask what they want to diagram
 3. Determine the appropriate diagram type from the description (or ask if ambiguous)
-4. Call `mcp__plugin_miro_miro__draft_diagram_new` with:
+4. Call `mcp__plugin_miro_miro__diagram_create` with:
    - `board_id`: The board URL
    - `text_description`: The diagram description
    - `diagram_type`: (optional) Specify if user requested a specific type

--- a/claude-plugins/miro/commands/doc.md
+++ b/claude-plugins/miro/commands/doc.md
@@ -30,7 +30,7 @@ The document supports:
    - If it's actual document content, use it directly
    - If it's a topic/request, generate appropriate document content
 3. If content is missing, ask what document they want to create
-4. Call `mcp__plugin_miro_miro__draft_doc_new` with:
+4. Call `mcp__plugin_miro_miro__doc_create` with:
    - `board_id`: The board URL
    - `content`: The markdown content
 5. Report success with a link to the board

--- a/claude-plugins/miro/commands/summarize.md
+++ b/claude-plugins/miro/commands/summarize.md
@@ -13,55 +13,31 @@ Parse the user's input to extract:
 1. **board-url** (required): Miro board URL
 2. **doc-type** (optional): Type of documentation to generate
 
-## Document Types
-
-| Type | Description |
-|------|-------------|
-| `project_summary` | High-level overview (recommended starting point) |
-| `style_guide` | Design tokens, colors, typography |
-| `screen_design_requirements` | UI/UX specifications per screen |
-| `screen_functional_requirements` | Feature requirements per screen |
-| `general_board_document` | Generic content extraction |
-| `technical_specification` | Technical implementation details |
-| `functional_requirements` | Business requirements |
-| `non_functional_requirements` | Performance, security, scalability |
-| `prototypes` | Interactive prototype HTML/CSS |
-
 ## Workflow
 
 1. If board URL is missing, ask the user for it
-2. If doc-type is not specified:
-   - First call with `["project_summary"]` to understand the board
-   - Present the summary and ask what specific documentation they need
-3. If doc-type is specified:
-   - Call with the requested document type(s)
-4. Call `mcp__plugin_miro_miro__context_get_board_docs` with:
-   - `board_id`: The board URL
-   - `document_types`: Array of requested types
-   - `item_id`: (optional) Filter to specific frame if URL contains moveToWidget
+2. Call `mcp__plugin_miro_miro__context_explore` to discover high-level items on the board:
+   - Returns frames, documents, prototypes, tables, and diagrams with their URLs
+3. Present the discovered items to the user
+4. For specific items the user wants to explore:
+   - Call `mcp__plugin_miro_miro__context_get` with the item URL (includes moveToWidget parameter)
+   - Returns detailed content based on item type (HTML for docs, summaries for frames, etc.)
 5. Present the extracted documentation to the user
 
 ## Examples
 
 **User input:** `/miro:summarize https://miro.com/app/board/abc=`
 
-**Action:** Generate project_summary first, then offer to generate more specific documentation based on board content.
+**Action:** Use context_explore to discover board contents, then offer to get details on specific items.
 
 ---
 
-**User input:** `/miro:summarize https://miro.com/app/board/abc= style_guide`
+**User input:** `/miro:summarize https://miro.com/app/board/abc=/?moveToWidget=123`
 
-**Action:** Extract and present the style guide documentation.
-
----
-
-**User input:** `/miro:summarize https://miro.com/app/board/abc=/?moveToWidget=123 technical_specification`
-
-**Action:** Extract technical specification from the specific frame/item indicated in the URL.
+**Action:** Use context_get to extract content from the specific item indicated in the URL.
 
 ## Tips
 
-- **Start with project_summary** - It provides recommendations for which document types are most relevant
-- **Filter by frame** - For large boards, focus on specific frames using URLs with `moveToWidget` parameter
-- **Multiple types** - Request multiple document types in one call for comprehensive coverage: `["functional_requirements", "technical_specification"]`
-- **Prototypes** - When extracting prototypes, images are returned as Miro URLs that can be downloaded with `miro__board_get_image_download_url`
+- **Start with context_explore** - Discover what's on the board before diving into details
+- **Use moveToWidget URLs** - Get detailed content from specific items using context_get
+- **Prototypes** - Images are returned as Miro URLs that can be downloaded with `miro__image_get_url`

--- a/claude-plugins/miro/commands/table.md
+++ b/claude-plugins/miro/commands/table.md
@@ -25,7 +25,7 @@ Parse the user's input to extract:
 3. Based on the table purpose, suggest appropriate columns using AskUserQuestion:
    - Propose a default column structure
    - Let user customize or accept defaults
-4. Call `mcp__plugin_miro_miro__table_create_new` with:
+4. Call `mcp__plugin_miro_miro__table_create` with:
    - `board_id`: The board URL
    - `title`: The table name
    - `columns`: Array of column definitions

--- a/claude-plugins/miro/skills/miro-mcp/SKILL.md
+++ b/claude-plugins/miro/skills/miro-mcp/SKILL.md
@@ -14,16 +14,16 @@ Miro MCP (Model Context Protocol) enables Claude to interact directly with Miro 
 The Miro MCP provides these tool categories:
 
 ### Content Creation
-- **`miro__draft_diagram_new`** - Generate diagrams from text descriptions
-- **`miro__draft_doc_new`** - Create markdown documents on boards
-- **`miro__table_create_new`** - Create tables with text and select columns
+- **`miro__diagram_create`** - Generate diagrams from text descriptions
+- **`miro__doc_create`** - Create markdown documents on boards
+- **`miro__table_create`** - Create tables with text and select columns
 - **`miro__table_sync_rows`** - Add or update table rows
 
 ### Content Reading
-- **`miro__board_get_items`** - List items on a board with filtering
-- **`miro__context_get_board_docs`** - Extract typed documentation from boards
+- **`miro__board_list_items`** - List items on a board with filtering
+- **`miro__context_get`** - Extract text context from specific board items
 - **`miro__table_list_rows`** - Read table data with filtering
-- **`miro__board_get_image_data`** - Get image content from boards
+- **`miro__image_get_data`** - Get image content from boards
 
 ## Board URLs and IDs
 
@@ -35,7 +35,7 @@ When a URL includes `moveToWidget` or `focusWidget` parameters, the item_id is e
 
 ## Creating Diagrams
 
-Use `miro__draft_diagram_new` to create visual diagrams from text descriptions.
+Use `miro__diagram_create` to create visual diagrams from text descriptions.
 
 ### Supported Diagram Types
 - **flowchart** - Process flows, workflows, decision trees
@@ -75,7 +75,7 @@ Set `parent_id` to a frame ID to place the diagram inside that frame.
 
 ## Creating Documents
 
-Use `miro__draft_doc_new` to create Google Docs-style documents on boards.
+Use `miro__doc_create` to create Google Docs-style documents on boards.
 
 ### Supported Markdown
 - Headings: `# H1`, `## H2`, through `###### H6`
@@ -87,7 +87,7 @@ Use `miro__draft_doc_new` to create Google Docs-style documents on boards.
 
 ### Not Supported
 - Code blocks
-- Tables (use `miro__table_create_new` instead)
+- Tables (use `miro__table_create` instead)
 - Images
 
 ### Example Document
@@ -113,7 +113,7 @@ Use `miro__draft_doc_new` to create Google Docs-style documents on boards.
 
 ### Creating Tables
 
-Use `miro__table_create_new` to create tables with typed columns.
+Use `miro__table_create` to create tables with typed columns.
 
 **Column Types:**
 - **text** - Free-form text entry
@@ -173,33 +173,37 @@ Use `miro__table_list_rows` to read table contents. Filter by column value:
 filter_by: "Status=In Progress"
 ```
 
-## Extracting Board Documentation
+## Extracting Board Content
 
-Use `miro__context_get_board_docs` to generate structured documentation from board content.
+### Discovering Board Contents
 
-### Document Types
+Use `miro__context_explore` to get a high-level view of what's on a board:
+- Returns frames, documents, prototypes, tables, and diagrams
+- Each item includes its URL and title
+- Use this to understand board structure before getting details
 
-| Type | Description |
-|------|-------------|
-| `project_summary` | High-level overview, recommended starting point |
-| `style_guide` | Design tokens, colors, typography |
-| `screen_design_requirements` | UI/UX specifications per screen |
-| `screen_functional_requirements` | Feature requirements per screen |
-| `general_board_document` | Generic board content extraction |
-| `technical_specification` | Technical implementation details |
-| `functional_requirements` | Business requirements |
-| `non_functional_requirements` | Performance, security, scalability |
-| `prototypes` | Interactive prototype HTML/CSS |
+### Getting Item Details
+
+Use `miro__context_get` to extract detailed content from specific items:
+
+| Item Type | Returns |
+|-----------|---------|
+| Documents | HTML markup of the document content |
+| Prototype screens | HTML markup representing the UI/layout |
+| Prototype containers | AI-generated map of all screens with navigation flow |
+| Frames | AI-generated summary of frame contents |
+| Tables | Formatted table data |
+| Diagrams | AI-generated description and analysis |
 
 ### Workflow
 
-1. Start with `project_summary` to understand board structure
-2. Based on recommendations, request specific document types
-3. Filter to specific frames using `item_id` parameter
+1. Call `context_explore` to discover board contents
+2. Identify items of interest from the results
+3. Call `context_get` with specific item URLs (with moveToWidget parameter)
 
 ## Browsing Board Items
 
-Use `miro__board_get_items` to explore board contents.
+Use `miro__board_list_items` to explore board contents.
 
 ### Filtering by Type
 - `frame` - Frames/containers
@@ -239,19 +243,19 @@ Use `cursor` from previous response to fetch next page. Default limit is capped 
 - Use key_column for idempotent updates
 
 ### For Context Extraction
-- Start with project_summary
+- Start with context_explore to discover board contents
 - Focus on specific frames when boards are large
-- Request multiple document types for comprehensive coverage
+- Use context_get with item URLs for detailed content
 
 ## Quick Reference
 
 | Task | Tool | Key Parameters |
 |------|------|----------------|
-| Create flowchart | `draft_diagram_new` | board_id, text_description, diagram_type="flowchart" |
-| Create document | `draft_doc_new` | board_id, content (markdown) |
-| Create table | `table_create_new` | board_id, title, columns |
+| Create flowchart | `diagram_create` | board_id, text_description, diagram_type="flowchart" |
+| Create document | `doc_create` | board_id, content (markdown) |
+| Create table | `table_create` | board_id, title, columns |
 | Add table rows | `table_sync_rows` | board_id, item_id, rows, key_column |
-| Get board summary | `context_get_board_docs` | board_id, document_types=["project_summary"] |
-| List frames | `board_get_items` | board_id, item_type="frame" |
+| Get item context | `context_get` | item_url (with moveToWidget parameter) |
+| List frames | `board_list_items` | board_id, item_type="frame" |
 
 See [tools-reference.md](references/tools-reference.md) for complete parameter documentation.

--- a/claude-plugins/miro/skills/miro-mcp/references/tools-reference.md
+++ b/claude-plugins/miro/skills/miro-mcp/references/tools-reference.md
@@ -21,7 +21,7 @@ Identifies a specific item on the board (frame, table, image, etc.). Can be:
 
 ## Content Creation Tools
 
-### miro__draft_diagram_new
+### miro__diagram_create
 
 Create diagrams from text descriptions.
 
@@ -46,7 +46,7 @@ Create diagrams from text descriptions.
 
 ---
 
-### miro__draft_doc_new
+### miro__doc_create
 
 Create markdown documents on boards.
 
@@ -72,7 +72,7 @@ Create markdown documents on boards.
 
 ---
 
-### miro__table_create_new
+### miro__table_create
 
 Create tables with typed columns.
 
@@ -140,7 +140,7 @@ Add or update table rows.
 
 ## Content Reading Tools
 
-### miro__board_get_items
+### miro__board_list_items
 
 List items on a board with pagination.
 
@@ -168,34 +168,27 @@ List items on a board with pagination.
 
 ---
 
-### miro__context_get_board_docs
+### miro__context_get
 
-Extract typed documentation from boards.
+Get text context from a specific item on a Miro board.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| board_id | string | Yes | Board ID or URL |
-| document_types | array | Yes | Types of documentation to generate |
-| item_id | string | No | Filter to specific frame/container |
+| item_url | string | Yes | Miro board URL with `moveToWidget` parameter identifying the item |
 
-**Document Types:**
+**Returns by Item Type:**
 
-| Type | Description | Best For |
-|------|-------------|----------|
-| `project_summary` | High-level overview with recommendations | Starting point, understanding board structure |
-| `style_guide` | Design tokens, colors, typography, spacing | Design handoff, consistency documentation |
-| `screen_design_requirements` | UI/UX specifications per screen | Designer-developer handoff |
-| `screen_functional_requirements` | Feature requirements per screen | Product requirements |
-| `general_board_document` | Generic content extraction | Any board content |
-| `technical_specification` | Implementation details | Engineering documentation |
-| `functional_requirements` | Business/feature requirements | PRDs, feature specs |
-| `non_functional_requirements` | Performance, security, scalability | Architecture decisions |
-| `prototypes` | Interactive prototype HTML/CSS | Design implementation |
+| Item Type | Returns |
+|-----------|---------|
+| Documents | HTML markup of the document content |
+| Prototype screens | HTML markup representing the UI/layout |
+| Prototype containers | AI-generated map of all screens with navigation flow |
+| Frames | AI-generated summary of frame contents |
+| Tables | Formatted table data |
+| Diagrams | AI-generated description and analysis |
 
-**Recommended Workflow:**
-1. Start with `["project_summary"]`
-2. Review recommendations in summary
-3. Request specific types based on board content
+**Example URL:**
+`https://miro.com/app/board/uXjVGeTCXKY=/?moveToWidget=3458764654510025479`
 
 ---
 
@@ -220,7 +213,7 @@ Read table data with filtering and pagination.
 
 ---
 
-### miro__board_get_image_download_url
+### miro__image_get_url
 
 Get download URL for an image item.
 
@@ -231,7 +224,7 @@ Get download URL for an image item.
 
 ---
 
-### miro__board_get_image_data
+### miro__image_get_data
 
 Get image data (base64 or visual) for an image item.
 

--- a/docs/claude-code/miro.md
+++ b/docs/claude-code/miro.md
@@ -141,19 +141,16 @@ Generate documentation from board content.
 **Arguments:**
 - `board-url` (required) - Miro board URL
 
-**Document Types Generated:**
-- `project_summary` - High-level overview
-- `style_guide` - Design tokens, colors, typography
-- `screen_design_requirements` - UI/UX specifications
-- `technical_specification` - Implementation details
-- `functional_requirements` - Business requirements
+**Workflow:**
+1. Uses `context_explore` to discover board contents (frames, documents, prototypes, tables, diagrams)
+2. Uses `context_get` with specific item URLs to extract detailed content
 
 **Example:**
 ```
 /miro:summarize https://miro.com/app/board/abc=
 ```
 
-Start with project summary to understand board structure, then request specific document types.
+Discovers board contents first, then offers to get details on specific items.
 
 ## Skills
 

--- a/docs/claude-code/plugin-development.md
+++ b/docs/claude-code/plugin-development.md
@@ -122,7 +122,7 @@ Parse user input to extract:
 
 1. If board URL is missing, ask the user
 2. If description is unclear, ask for clarification
-3. Call `mcp__miro__draft_diagram_new` with the parameters
+3. Call `mcp__miro__diagram_create` with the parameters
 4. Report success with a link to the board
 ```
 

--- a/docs/mcp/tools-reference.md
+++ b/docs/mcp/tools-reference.md
@@ -4,7 +4,7 @@ Overview of available Miro MCP tools. For complete parameter documentation, see 
 
 ## Content Creation
 
-### miro__diagram_get_dsl_spec
+### miro__diagram_get_dsl
 
 Get the DSL format specification for a diagram type before creating diagrams.
 
@@ -12,7 +12,7 @@ Get the DSL format specification for a diagram type before creating diagrams.
 - `board_id` (required) - Board ID or URL
 - `diagram_type` (required) - `flowchart`, `uml_class`, `uml_sequence`, `entity_relationship`
 
-### miro__diagram_create_new
+### miro__diagram_create
 
 Create a diagram from DSL text.
 
@@ -23,7 +23,7 @@ Create a diagram from DSL text.
 - `x`, `y` (optional) - Position on board
 - `parent_id` (optional) - Frame ID to place diagram in
 
-### miro__draft_doc_new / miro__doc_new
+### miro__doc_create
 
 Create a markdown document on a board.
 
@@ -39,7 +39,7 @@ Create a markdown document on a board.
 - Lists (ordered and unordered)
 - Links (`[text](url)`)
 
-### miro__table_create_new
+### miro__table_create
 
 Create a table with typed columns.
 
@@ -64,7 +64,7 @@ Add or update table rows.
 
 ## Content Reading
 
-### miro__board_get_items
+### miro__board_list_items
 
 List items on a board with filtering.
 
@@ -110,7 +110,7 @@ Read table rows with filtering.
 - `limit` (optional) - Max rows
 - `next_cursor` (optional) - Pagination
 
-### miro__board_get_image_data
+### miro__image_get_data
 
 Get image content from a board.
 
@@ -118,7 +118,7 @@ Get image content from a board.
 - `board_id` (required) - Board ID or URL
 - `item_id` (optional) - Image item ID
 
-### miro__board_get_image_download_url
+### miro__image_get_url
 
 Get download URL for an image item.
 
@@ -128,7 +128,7 @@ Get download URL for an image item.
 
 ## Document Editing
 
-### miro__doc_read
+### miro__doc_get
 
 Read document content and version.
 
@@ -136,7 +136,7 @@ Read document content and version.
 - `board_id` (required) - Board ID or URL
 - `item_id` (optional) - Document ID
 
-### miro__doc_edit
+### miro__doc_update
 
 Edit document using find-and-replace.
 
@@ -159,11 +159,11 @@ When URLs include `moveToWidget` or `focusWidget` parameters, the item ID is ext
 
 | Task | Tool |
 |------|------|
-| Create flowchart | `diagram_create_new` |
-| Create document | `doc_new` |
-| Create table | `table_create_new` |
+| Create flowchart | `diagram_create` |
+| Create document | `doc_create` |
+| Create table | `table_create` |
 | Add table rows | `table_sync_rows` |
-| List frames | `board_get_items` (item_type=frame) |
+| List frames | `board_list_items` (item_type=frame) |
 | Get board overview | `context_explore` |
 | Extract documentation | `context_get` |
 


### PR DESCRIPTION
## Summary
- Updated all MCP tool references to use current naming convention
- Removed references to deprecated `context_get_board_docs` tool
- Updated documentation workflows to use `context_explore` + `context_get`

## Tool Renames
| Old Name | New Name |
|----------|----------|
| diagram_get_dsl_spec | diagram_get_dsl |
| board_get_items | board_list_items |
| table_create_new | table_create |
| doc_edit | doc_update |
| doc_new/draft_doc_new | doc_create |
| doc_read | doc_get |
| diagram_create_new/draft_diagram_new | diagram_create |
| board_get_image_download_url | image_get_url |
| board_get_image_data | image_get_data |
| context_get_board_docs | context_get + context_explore |

## Test plan
- [ ] Verify commands work with updated tool names
- [ ] Test /miro:diagram, /miro:doc, /miro:table commands
- [ ] Test /miro:summarize with new context_explore workflow


🤖 Generated with [Claude Code](https://claude.ai/code)