### PR TITLE
fix: improve miro-ast visualize command based on user feedback

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -163,6 +163,35 @@
         "visualization",
         "collaboration"
       ]
+    },
+    {
+      "name": "miro-ast",
+      "description": "Visualize tree-sitter AST output on Miro boards. Parse any source file and create an interactive syntax tree diagram.",
+      "source": "./claude-plugins/miro-ast",
+      "category": "development",
+      "version": "1.0.0",
+      "author": {
+        "name": "Miro",
+        "email": "support@miro.com"
+      },
+      "homepage": "https://miro.com",
+      "repository": "https://github.com/miroapp/miro-ai",
+      "license": "MIT",
+      "keywords": [
+        "miro",
+        "ast",
+        "tree-sitter",
+        "syntax-tree",
+        "visualization",
+        "code-analysis",
+        "parsing"
+      ],
+      "tags": [
+        "development",
+        "visualization",
+        "code-analysis",
+        "parsing"
+      ]
     }
   ]
 }

--- a/claude-plugins/miro-ast/.claude-plugin/plugin.json
+++ b/claude-plugins/miro-ast/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "miro-ast",
+  "version": "1.0.0",
+  "description": "Visualize tree-sitter AST output on Miro boards. Parse any source file and create an interactive syntax tree diagram.",
+  "keywords": [
+    "miro",
+    "ast",
+    "tree-sitter",
+    "syntax-tree",
+    "visualization",
+    "code-analysis"
+  ],
+  "skills": "./skills/"
+}

--- a/claude-plugins/miro-ast/README.md
+++ b/claude-plugins/miro-ast/README.md
@@ -1,0 +1,54 @@
+# miro-ast
+
+Visualize tree-sitter AST output on Miro boards. Parse any source file in your project and create an interactive syntax tree diagram.
+
+## Prerequisites
+
+- `miro` plugin installed (provides Miro MCP tools)
+- [tree-sitter CLI](https://tree-sitter.github.io/tree-sitter/) installed (`brew install tree-sitter-cli`)
+- Language grammar configured for your target language (run `tree-sitter init-config` if first time)
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/miro-ast:visualize` | Parse a file and visualize its AST on a Miro board |
+
+### Usage
+
+```bash
+# Auto-detect project entry point
+/miro-ast:visualize <board-url>
+
+# Specific file
+/miro-ast:visualize <board-url> src/parser.ts
+
+# Limit depth
+/miro-ast:visualize <board-url> main.py --depth 5
+
+# Filter node types
+/miro-ast:visualize <board-url> app.ts --filter function_definition,class_definition
+
+# Concrete syntax tree
+/miro-ast:visualize <board-url> index.js --cst
+```
+
+Only `board-url` is required. When no file is specified, the plugin auto-detects the project entry point (e.g., `src/index.ts`, `main.py`, `main.go`).
+
+## Local Testing
+
+```bash
+# Test from a target project directory
+cd /path/to/your/project
+claude --plugin-dir /path/to/miro-ai/claude-plugins/miro-ast
+
+# Then run the command
+/miro-ast:visualize https://miro.com/app/board/your-board-id=
+```
+
+The `--plugin-dir` flag loads the plugin for the current session without installing it globally.
+
+## What Gets Created
+
+1. **AST Mindmap Diagram** — Structural overview showing classes, functions, methods, and module organization
+2. **Summary Document** — File metadata, node type frequency, and parsing options used

--- a/claude-plugins/miro-ast/commands/visualize.md
+++ b/claude-plugins/miro-ast/commands/visualize.md
@@ -1,0 +1,214 @@
+---
+description: Parse a source file with tree-sitter and visualize its AST on a Miro board
+argument-hint: "<board-url> [file-path] [--depth N] [--filter type1,type2] [--cst]"
+allowed-tools: Bash(tree-sitter:*), Bash(which:*), Bash(test:*), Bash(wc:*), Bash(ls:*), Bash(find:*), Bash(brew:*), Bash(npm:*), Bash(cargo:*), Bash(cat:*), Bash(head:*), mcp__miro__*
+---
+
+# Visualize AST on Miro Board
+
+Parse a source file using tree-sitter and create an interactive syntax tree visualization on a Miro board.
+
+## Arguments
+
+- `board-url` (required): Miro board URL
+- `file-path` (optional): Path to source file relative to CWD. If omitted, auto-detect entry point.
+- `--depth N` (optional): Maximum tree depth to visualize. Default: **5**
+- `--filter type1,type2` (optional): Comma-separated node types to include (e.g., `function_definition,class_definition`)
+- `--cst` (optional): Show concrete syntax tree instead of abstract syntax tree
+
+## Workflow
+
+### 1. Parse Arguments
+
+Extract the board URL from arguments. It must be a valid Miro board URL (contains `miro.com/app/board/`).
+
+If a file path is provided, resolve it relative to the user's current working directory.
+
+If no file path is provided, auto-detect the project entry point.
+
+### 2. Check tree-sitter Installation
+
+```bash
+which tree-sitter
+```
+
+If tree-sitter is not installed, inform the user and offer installation options:
+- `brew install tree-sitter-cli` (macOS/Linux)
+- `npm install -g tree-sitter-cli` (cross-platform)
+- `cargo install --locked tree-sitter-cli` (Rust)
+
+**Ask the user which method they prefer before installing. Do not install automatically.**
+
+### 2b. Verify Language Grammar
+
+After confirming tree-sitter is installed, verify the grammar works for the target file:
+
+```bash
+tree-sitter parse <file> 2>&1 | head -5
+```
+
+If parsing fails with a grammar-related error (e.g., "No language found", "Unknown language"):
+
+1. Run `tree-sitter init-config` to create the config file
+2. Clone the appropriate grammar repo (e.g., `tree-sitter-python`, `tree-sitter-typescript`)
+3. Add the grammar's parent directory to `parser-directories` in the tree-sitter config
+
+**Do not install grammars automatically — show the user the steps and ask before proceeding.**
+
+### 3. Resolve Source File
+
+**If file-path is provided:**
+Resolve relative to CWD. Verify the file exists with `test -f <path>`.
+
+**If file-path is omitted, auto-detect entry point in priority order:**
+
+1. `src/index.ts`, `src/index.js`, `src/main.ts`, `src/main.js`
+2. `index.ts`, `index.js`, `main.ts`, `main.js`
+3. `src/app.ts`, `src/app.js`, `app.ts`, `app.js`
+4. `main.py`, `app.py`, `src/main.py`, `src/app.py`
+5. `src/*/main.py`, `src/*/__main__.py`, `*/__main__.py`
+6. `main.go`, `cmd/main.go`
+7. `src/main.rs`, `src/lib.rs`
+8. `Main.java` (search in `src/`)
+9. Check `package.json` → `main` field if it points to a source file
+10. Check `pyproject.toml` → `[project.scripts]` or `[tool.poetry.scripts]` for Python entry points
+11. Check `setup.py` or `setup.cfg` → `console_scripts` for Python entry points
+12. Fall back: first source file (`*.ts`, `*.js`, `*.py`, `*.go`, `*.rs`, `*.java`, `*.c`, `*.cpp`) in CWD root or `src/`
+
+Check each candidate with `test -f <path>` and use the first match.
+
+If no suitable file is found, tell the user and ask them to specify a file path.
+
+### 4. Analyze Source Structure
+
+Use two complementary sources to build a structural understanding of the file.
+
+**4a. Get node type statistics with tree-sitter:**
+
+```bash
+tree-sitter parse <absolute-file-path> | grep -o '([a-z_]*' | sed 's/(//' | sort | uniq -c | sort -rn | head -30
+```
+
+If `--cst` flag is set, add the `-c` flag to the parse command. This provides a frequency count of node types without processing the full S-expression tree.
+
+**If parsing fails:**
+- Show the stderr output to the user
+- Common issue: missing language grammar. Refer the user to step 2b for grammar setup.
+
+**4b. Read the source file directly:**
+
+- For files under 500 lines: `cat <absolute-file-path>`
+- For larger files: `head -200 <absolute-file-path>`
+
+This is the primary source for understanding the file's structure — classes, functions, methods, imports, and exports.
+
+**4c. Apply filters and depth:**
+
+- `--depth N` (default: **5**): Controls how many nesting levels to include in the structural description
+- `--filter type1,type2`: Only include matching structural elements (e.g., `function_definition,class_definition`)
+
+### 5. Build Structural Description
+
+From the source file content (step 4b) and node statistics (step 4a), compose a natural language hierarchy describing the file's structure.
+
+**Structural hierarchy format:**
+
+```
+Module: {filename}
+  Import: os, sys, pathlib
+  Import: from typing import List, Optional
+  Class: ConfigManager
+    Method: __init__(self, path)
+    Method: load(self)
+    Method: save(self, data)
+    Method: validate(self)
+  Function: parse_args()
+  Function: main()
+  Constant: DEFAULT_CONFIG, VERSION
+```
+
+**Rules:**
+
+- Target **30-60 structural nodes** — enough for a useful overview without visual noise
+- Use semantic labels: `Class`, `Function`, `Method`, `Interface`, `Import`, `Export`, `Constant`, `Type`, `Enum`
+- When a container (class, module) has more than 8 members, show the first 6 and add a summary: `... (N more members)`
+- Apply `--depth` to control nesting (e.g., depth 3 shows Module → Class → Method but not method internals)
+- Apply `--filter` to include only matching semantic types
+- Include function/method signatures (name + parameters) but not body details
+
+### 6. Create Miro Board Artifacts
+
+**Artifact 1: Structure Diagram (mindmap)**
+
+Use the Miro `diagram_create` tool to create the mindmap:
+- Board: the board URL from arguments
+- Text description: pass the hierarchical description directly as natural language — do not generate Mermaid or PlantUML syntax
+- Diagram type: `mindmap`
+- Position: x=0, y=0
+
+**Artifact 2: Summary Document**
+
+Use the Miro `doc_create` tool to create a summary document:
+- Board: the board URL from arguments
+- Position: x=-1500, y=0
+- Content (plain text with headings — no code blocks or tables, which are not supported by Miro doc_create):
+
+```
+AST: {filename}
+
+Language: {detected language from extension}
+File: {absolute file path}
+Structural elements visualized: {count of nodes in description}
+Max depth: {actual max depth used}
+
+Node Type Frequency (top 10 from tree-sitter)
+
+{type}: {count}
+{type}: {count}
+...
+
+Semantic Labels
+
+Class — class or struct definition
+Function — top-level function
+Method — function inside a class
+Interface — interface or protocol
+Import — import or require statement
+Export — exported symbol
+Constant — top-level constant or enum value
+Type — type alias or typedef
+
+Options
+
+Depth limit: {N}
+Filter: {types or "none"}
+Tree type: {AST or CST}
+```
+
+### 7. Report Results
+
+Output to the user:
+1. Link to the Miro board
+2. Which file was parsed (and whether it was auto-detected)
+3. Number of nodes visualized
+4. Any truncation applied (depth reduction, collapsed nodes)
+5. Suggest re-running with `--filter` for focused views if the tree was large
+
+## Examples
+
+```
+# Auto-detect entry point
+/miro-ast:visualize https://miro.com/app/board/abc123=
+
+# Specific file
+/miro-ast:visualize https://miro.com/app/board/abc123= src/utils/parser.ts
+
+# With depth limit
+/miro-ast:visualize https://miro.com/app/board/abc123= main.py --depth 5
+
+# Filter to only show function and class definitions
+/miro-ast:visualize https://miro.com/app/board/abc123= app.ts --filter function_definition,class_definition
+
+# Concrete syntax tree
+/miro-ast:visualize https://miro.com/app/board/abc123= index.js --cst
+```

--- a/claude-plugins/miro-ast/skills/ast-visualization/SKILL.md
+++ b/claude-plugins/miro-ast/skills/ast-visualization/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: ast-visualization
+description: Knowledge about tree-sitter AST parsing and visualization strategies for source code analysis
+---
+
+# AST Visualization with Tree-sitter
+
+## What is Tree-sitter?
+
+Tree-sitter is an incremental parsing system that generates concrete syntax trees for source files. It supports 150+ languages and produces S-expression output representing the full parse tree.
+
+## S-expression Format
+
+Tree-sitter outputs ASTs as nested S-expressions with position metadata:
+
+```
+(module [0, 0] - [10, 0]
+  (function_definition [0, 0] - [5, 0]
+    name: (identifier [0, 4] - [0, 11])
+    parameters: (parameters [0, 11] - [0, 13])
+    body: (block [1, 4] - [5, 0]
+      (expression_statement [1, 4] - [1, 20]
+        (call [1, 4] - [1, 20]
+          function: (identifier [1, 4] - [1, 9])
+          arguments: (argument_list [1, 9] - [1, 20]))))))
+```
+
+> **Note:** The visualize command uses tree-sitter only for node type statistics (frequency counts), not for full S-expression parsing. The structural description is built by reading the source file directly, which is more token-efficient and produces cleaner diagrams.
+
+Each node contains:
+- **Type**: e.g., `function_definition`, `identifier`
+- **Position**: `[start_line, start_col] - [end_line, end_col]`
+- **Named fields**: e.g., `name:`, `body:`, `parameters:`
+- **Children**: nested nodes
+
+## Common Node Types
+
+| Category | Node Types |
+|----------|-----------|
+| Declarations | `function_definition`, `class_definition`, `variable_declaration`, `method_definition` |
+| Statements | `if_statement`, `for_statement`, `while_statement`, `return_statement`, `try_statement` |
+| Expressions | `call_expression`, `binary_expression`, `assignment_expression`, `member_expression` |
+| Structural | `module`, `program`, `block`, `body`, `statement_block` |
+| Literals | `string`, `number`, `boolean`, `null`, `template_string` |
+| Types | `type_annotation`, `type_identifier`, `generic_type`, `union_type` |
+
+## Visualization Strategy
+
+### Structural Description Strategy
+
+The visualization uses a two-source approach:
+
+1. **Tree-sitter** — provides node type frequency statistics via `tree-sitter parse | grep | sort | uniq -c`
+2. **Source file** — read directly (`cat` or `head`) to extract the actual structural hierarchy
+
+This avoids parsing the full S-expression output (which is token-expensive and error-prone) and instead produces a clean natural language description of the file's architecture. The description is passed directly to Miro's `diagram_create` tool as a `mindmap` — no Mermaid or PlantUML syntax is needed.
+
+### Semantic Node Vocabulary
+
+| Label | Maps to AST Node Types |
+|-------|----------------------|
+| Class | `class_definition`, `class_declaration`, `struct_item` |
+| Function | `function_definition`, `function_declaration`, `arrow_function` |
+| Method | `method_definition`, `function_definition` (inside class) |
+| Interface | `interface_declaration`, `protocol`, `abstract_class_declaration` |
+| Import | `import_statement`, `import_from_statement`, `require` |
+| Export | `export_statement`, `export_default_declaration` |
+| Constant | `const`, `let` (top-level), `enum_item` |
+| Type | `type_alias_declaration`, `typedef`, `type_annotation` |
+| Enum | `enum_declaration`, `enum_definition` |
+
+### Depth and Size Management
+
+- **Default depth: 5** — captures module → class → method structure without excessive detail
+- **Node target: 30-60** — enough for a useful overview without visual noise
+- **Node collapsing**: When a container has >6 members, show first 6 + summary `... (N more members)`
+- **Type filtering**: Use `--filter` to show only specific semantic types (e.g., `function_definition,class_definition`)
+
+### Language Support
+
+Well-supported languages include: Python, JavaScript, TypeScript, Go, Rust, C, C++, Java, Ruby, C#, Swift, Kotlin, PHP, Bash, HTML, CSS, JSON, YAML, TOML, and many more.
+
+Tree-sitter auto-detects language from file extension.


### PR DESCRIPTION
## Summary

- Fix `brew install` package name (`tree-sitter` → `tree-sitter-cli`)
- Add grammar setup troubleshooting step (2b) with `tree-sitter init-config` guidance
- Expand Python entry point auto-detection (glob patterns, `pyproject.toml`, `setup.py`/`setup.cfg`)
- Replace S-expression → Mermaid workflow with source-reading structural description approach
- Use generic tool references instead of `mcp__miro__` in workflow text
- Reduce default depth from 10 to 5, target 30-60 nodes instead of 500
- Update summary doc template (no code blocks/tables, add semantic labels legend)
- Update SKILL.md with structural strategy, semantic vocabulary, remove `--scope`

## Test plan

- [x] Run `bun run validate` — all checks pass
- [x] Verify no references to `brew install tree-sitter` (without `-cli`) remain
- [x] Verify no `mcp__miro__` references in workflow body text
- [x] Confirm default depth is 5 and node target is 30-60 across all files
- [x] Test `/miro-ast:visualize` with a real board URL to verify end-to-end flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)