### PR TITLE
feat: add miro-agent skill with CLI, MCP, and browser tool routing

### DIFF
--- a/skills/miro-agent/SKILL.md
+++ b/skills/miro-agent/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: miro-agent
+description: Routes Miro board interactions to the optimal tool automatically. Uses Miro MCP server for content intelligence (docs, diagrams, tables, board context), miroctl CLI for full API CRUD (frames, shapes, images, uploads, boards, teams), and agent-browser for visual capture (screenshots, web interaction). Use when working with Miro boards, creating or reading board content, uploading images, capturing screenshots, or managing Miro resources.
+---
+
+# Interacting with Miro
+
+This skill routes Miro tasks to the right tool. The user describes what they want; the agent picks the tool.
+
+- **Miro MCP** — content intelligence: explore boards, create docs/diagrams/tables, AI-powered context
+- **miroctl** — full Miro API: CRUD all item types, file uploads, frames, boards, teams, bulk ops
+- **agent-browser** — visual capture: screenshots, web navigation, DOM interaction
+
+## Preflight
+
+Run once at the start of any Miro session. Do not skip steps.
+
+### Step 1: Check miroctl and agent-browser
+
+```bash
+bash scripts/preflight.sh
+```
+
+Returns JSON with install/auth status. Handle failures:
+
+| Status | Action |
+|--------|--------|
+| miroctl not installed | `brew install miroapp-dev/tap/miroctl` |
+| miroctl no token | Ask user: "Go to https://developers.miro.com/reference/get-access-token-context, click **Get access token**, select your team, and paste the token here." Then run `miroctl auth set-token <TOKEN>` |
+| miroctl token expired | Same as above — token lasts 1 hour |
+| agent-browser not installed | `bun install -g agent-browser && agent-browser install` |
+| agent-browser not in PATH | Add `~/.bun/bin` to PATH or use full path `~/.bun/bin/agent-browser` |
+
+### Step 2: Check MCP
+
+Try a lightweight MCP call to verify:
+
+```
+miro-mcp:board_list_items(board_id="<any_board_url>", limit=1)
+```
+
+| Result | Action |
+|--------|--------|
+| Tool not found | MCP server not configured. Guide user to add to MCP settings: `{"miro": {"type": "http", "url": "https://mcp.miro.com"}}` — then restart MCP connection |
+| Auth error | OAuth flow not completed. Ask user to restart MCP connection (triggers OAuth in browser) |
+| Success | MCP ready |
+
+**Note:** The MCP tool prefix depends on the server name in the user's config. It may be `miro:`, `miro-mcp:`, or another prefix. Use whatever prefix the tools are registered under.
+
+## Tool Routing
+
+### Quick Rules
+
+**Create** — MCP: docs, diagrams, tables. CLI: everything else.
+**Read** — MCP first (content intelligence). CLI fallback (raw JSON, positions, styles).
+**Update** — MCP: doc content, table rows. CLI: position, parent, style, delete.
+**Upload** — CLI only (images, documents, bulk).
+**Visual capture** — agent-browser only.
+
+For fallback chains and overlap resolution, see [reference/tool-selection.md](reference/tool-selection.md).
+
+### Routing Matrix
+
+| Content | Create | Read | Update/Delete |
+|---------|--------|------|---------------|
+| Document | MCP `doc_create` | MCP `doc_get` | MCP `doc_update` / CLI delete |
+| Diagram | MCP `diagram_create`* | MCP `context_get` | CLI delete |
+| Table | MCP `table_create` | MCP `table_list_rows` | MCP `table_sync_rows` / CLI delete |
+| Frame | CLI `frames create`** | MCP `board_list_items` or CLI | CLI `frames update` / delete |
+| Sticky note | CLI `sticky-notes create` | MCP or CLI | CLI update / delete |
+| Shape | CLI `shapes create` | MCP or CLI | CLI update / delete |
+| Card | CLI `cards create` | MCP or CLI | CLI update / delete |
+| Text | CLI `texts create` | MCP or CLI | CLI update / delete |
+| Image | CLI `images create-*` | MCP `image_get_data` | CLI update / delete |
+| Connector | CLI `connectors create` | CLI | CLI update / delete |
+| Embed | CLI `embeds create` | CLI | CLI update / delete |
+| Mind map node | CLI `mind-map-nodes create` | CLI | CLI delete |
+
+*Call `diagram_get_dsl` first (once per type per session)
+**Two-step: create then update for position/size (see Gotchas)
+
+### Board-Level Operations
+
+| Task | Tool |
+|------|------|
+| Find/list boards | CLI `boards list --all` |
+| Board metadata | CLI `boards get --board-id ID` |
+| Explore board structure | MCP `context_explore` |
+| Share board | CLI `board-members share` |
+| Tags | CLI `tags create/attach` |
+| Groups | CLI `groups create/un-group` |
+| Webhooks | CLI `webhooks create/list/delete` |
+| Upload image from file | CLI `images create-image-item-using-local-file --board-id ID --file ./img.png` |
+| Upload image from URL | CLI `images create-image-item-using-url` |
+| Upload document file | CLI `documents create-document-item-using-file-from-device` |
+| Bulk create items | CLI `bulk-operations create-items` |
+| Screenshot webpage | agent-browser `open` → `wait 1000` → `screenshot` |
+
+### Multi-Tool Chains
+
+| Task | Chain |
+|------|-------|
+| Screenshot page → upload to board | agent-browser screenshot → miroctl images upload → (sleep 2) → miroctl items update to move to frame |
+| Create frame with doc + diagram | miroctl frames create+update → MCP doc_create with parent_id → MCP diagram_create with parent_id |
+| Read board → implement feature | MCP context_explore → MCP context_get on relevant items → code changes |
+| Populate board from data | miroctl frames create → MCP table_create + table_sync_rows → MCP doc_create |
+
+## Board ID Extraction
+
+MCP accepts full Miro URLs — board_id and item_id are auto-extracted.
+
+miroctl needs the board ID extracted from the URL:
+
+```
+https://miro.com/app/board/BOARD_ID=/              → BOARD_ID=
+https://miro.com/app/board/BOARD_ID=/?moveToWidget=345... → BOARD_ID=
+```
+
+Pattern: segment after `/board/` up to `/` or `?`.
+
+```bash
+BOARD_ID=$(echo "$URL" | sed 's|.*/board/\([^/?]*\).*|\1|')
+```
+
+For miroctl, pass as: `--board-id $BOARD_ID`
+
+## Positioning
+
+Board coordinates: center at `(0, 0)`, positive X right, positive Y down.
+
+**Spacing** to prevent overlap: diagrams 2000–3000 units apart, tables 1500–2000, documents 500–1000.
+
+Use `parent_id` (MCP) or `items update` with `{"parent":{"id":"FRAME_ID"}}` (CLI) to place items inside frames. Coordinates become relative to the frame's top-left corner.
+
+## Error Handling
+
+### Token Expiry (miroctl)
+
+miroctl exits with code 3 on 401/403. On any auth error:
+
+1. Tell user: "Token expired. Get a fresh one from https://developers.miro.com/reference/get-access-token-context and paste it here."
+2. Run `miroctl auth set-token <NEW_TOKEN>`
+3. **Retry the exact command that failed.**
+
+### MCP Failures
+
+If an MCP tool returns an access or server error, fall back to miroctl:
+
+| MCP failure | CLI fallback |
+|-------------|-------------|
+| `context_explore` | `miroctl items get-items --board-id ID --limit 50` |
+| `board_list_items` | `miroctl items get-items-within-frame --board-id ID --parent-item-id FRAME_ID` |
+| `doc_get` | No equivalent — inform user |
+| `table_list_rows` | No equivalent — inform user |
+| `diagram_create` | No equivalent — inform user |
+
+## Gotchas
+
+**Frame creation requires two calls.** `miroctl frames create` only accepts title. Position, size, and style must be set via a follow-up update:
+
+```bash
+FRAME_ID=$(miroctl frames create --board-id $BID --data '{"data":{"title":"My Frame"}}' | jq -r '.id')
+miroctl frames update --board-id $BID --item-id $FRAME_ID --data '{
+  "position":{"x":0,"y":0},
+  "geometry":{"width":1600,"height":1200},
+  "style":{"fillColor":"#F5F6F8"}
+}'
+```
+
+**Sleep after image upload.** After `images create-image-item-using-local-file`, wait 2 seconds before moving the item to a frame. The API returns 404 if you call `items update` immediately.
+
+**Always read before editing docs.** MCP `doc_update` uses exact text find-and-replace. Always call `doc_get` first to get the precise text.
+
+**Always get DSL spec before creating diagrams.** Call `diagram_get_dsl` before `diagram_create`. Only needed once per diagram type per session.
+
+**`--all` breaks on cursor-based endpoints.** Endpoints like `items get-items` that use `--cursor` will fail on page 2+ due to cursor double-encoding. Use `--limit` and paginate manually with `--cursor`. Offset-based endpoints like `boards list` work fine with `--all`.
+
+**`items get-items` minimum limit is 10.** The API rejects `--limit` values below 10.
+
+**Mindmap is not available via `diagram_create`.** Only `flowchart`, `uml_class`, `uml_sequence`, `entity_relationship` are supported. Mindmap uses a separate backend API not exposed through MCP tools.
+
+**miroctl output is JSON.** Parse with `jq`. Capture IDs: `| jq -r '.id'`
+
+**Wait after page load for screenshots.** After `agent-browser open <url>`, run `agent-browser wait 1000` before taking a screenshot — pages with animations or transitions need time to settle.
+
+## Tool References
+
+**CRITICAL: When you need tool details, load the quick reference first.** It is a small index with line pointers into the full reference. Read only the specific line range you need from the full reference — never load it entirely.
+
+Quick references (load these):
+
+- **[miroctl-quick.md](reference/miroctl-quick.md)** — command index, CRUD pattern, key gotchas
+- **[miro-mcp-quick.md](reference/miro-mcp-quick.md)** — tool index, essential patterns
+- **[agent-browser-quick.md](reference/agent-browser-quick.md)** — command index, screenshot pattern
+
+Full references (read by line range from quick ref):
+
+- **[miroctl.md](reference/miroctl.md)** — command patterns, CRUD syntax, file uploads
+- **[miro-mcp.md](reference/miro-mcp.md)** — tool signatures, parameters, examples, best practices
+- **[agent-browser.md](reference/agent-browser.md)** — navigation, interaction, screenshots
+- **[tool-selection.md](reference/tool-selection.md)** — routing rules, fallback chains, overlap resolution
+
+## Testing
+
+To test the skill, follow **[scripts/test-playbook.md](scripts/test-playbook.md)**. Always create a fresh board — never reuse an existing one. **Print the board URL to the user and wait for confirmation before starting tests** — this lets them open the board and watch items appear in real time. Run Part 1 (CLI) via bash, Part 2 (MCP) via MCP tool calls. Clean up the board when done.

--- a/skills/miro-agent/agents.md
+++ b/skills/miro-agent/agents.md
@@ -1,0 +1,88 @@
+# Maintaining the miro-agent Skill
+
+## When to Update
+
+Update this skill when:
+- miroctl CLI adds, removes, or changes commands or flags
+- Miro MCP server adds, removes, or changes tools or parameters
+- agent-browser changes commands
+
+## Source Repos
+
+Before updating, ask the user for the locations of:
+- **miroctl repo** — contains `docs/cli-reference.md` (auto-generated from --help)
+- **miro-mcp-server repo** — contains `src/server_mcp/servers/` (tool implementations)
+
+If repos are unavailable, use live tool output:
+- CLI: run `miroctl <command> --help` for each command group
+- MCP: inspect tool definitions from the active MCP server connection
+
+## Update Workflow
+
+### 1. Detect Changes
+
+**For miroctl:**
+- Read `docs/cli-reference.md` in the miroctl repo
+- Compare against `reference/miroctl.md` — look for new/changed/removed subcommands and flags
+- Run `miroctl <command> --help` to verify any changes
+
+**For MCP:**
+- Read tool implementations under `src/server_mcp/servers/` in the MCP server repo
+- Look for new tools, changed parameters, new enum values (e.g., diagram types)
+- Compare against `reference/miro-mcp.md`
+
+**For agent-browser:**
+- Run `agent-browser --help` and compare against `reference/agent-browser.md`
+
+### 2. Update Full References
+
+Edit the affected full reference:
+- `reference/miroctl.md` — for CLI changes
+- `reference/miro-mcp.md` — for MCP changes
+- `reference/agent-browser.md` — for browser changes
+
+Keep stable section structure — each command/tool gets a `##` heading.
+
+### 3. Update Quick References
+
+After editing a full reference, re-read it to get current line numbers. Update every line range in the corresponding quick reference:
+- `reference/miroctl-quick.md`
+- `reference/miro-mcp-quick.md`
+- `reference/agent-browser-quick.md`
+
+### 4. Update SKILL.md (if needed)
+
+Only update SKILL.md if:
+- New content types added → new row in routing matrix
+- Existing tool capabilities changed → routing changes
+- New gotchas discovered
+- Tool references section needs updating
+
+### 5. Run Tests
+
+```bash
+# CLI smoke test + MCP verification
+# Follow scripts/test-playbook.md — Part 1 (CLI) can run via bash,
+# Part 2 (MCP) requires an active agent session with MCP connected.
+```
+
+Fix any failures before committing.
+
+### 6. Verify Line Pointers
+
+Read each quick reference and confirm every line range points to the correct section in the full reference. This is the most error-prone step — do not skip.
+
+## File Map
+
+| File | Purpose | When to update |
+|------|---------|---------------|
+| `SKILL.md` | Routing rules, gotchas, positioning | New content types or tool capabilities |
+| `reference/miroctl.md` | Full CLI reference | CLI commands/flags change |
+| `reference/miroctl-quick.md` | CLI index + line pointers | After any miroctl.md edit |
+| `reference/miro-mcp.md` | Full MCP reference | MCP tools/params change |
+| `reference/miro-mcp-quick.md` | MCP index + line pointers | After any miro-mcp.md edit |
+| `reference/agent-browser.md` | Full browser reference | Browser commands change |
+| `reference/agent-browser-quick.md` | Browser index + line pointers | After any agent-browser.md edit |
+| `reference/tool-selection.md` | Overlap resolution, fallback chains | Routing logic changes |
+| `scripts/test-playbook.md` | CLI + MCP smoke tests | New operations to test |
+| `agents.md` | This file — maintenance instructions | Workflow changes |

--- a/skills/miro-agent/reference/agent-browser-quick.md
+++ b/skills/miro-agent/reference/agent-browser-quick.md
@@ -1,0 +1,34 @@
+# agent-browser — Quick Reference
+
+Full reference: [reference/agent-browser.md](agent-browser.md)
+
+## Command Index
+
+| Command group | Key commands | Full ref lines |
+|---------------|-------------|---------------|
+| Navigation | open, back, forward, reload, close | 5-13 |
+| Screenshots & PDF | screenshot (file/stdout/--full), pdf | 15-29 |
+| Accessibility snapshot | snapshot (-i interactive, -c compact, -d depth, -s selector) | 31-47 |
+| Interaction | click, type, fill, press, hover, check, select, scroll, wait | 49-64 |
+| Semantic find | find role/text/label/placeholder/testid [action] | 66-78 |
+| Get information | get text/html/value/attr/title/url/count | 80-90 |
+| JavaScript | eval "expression" | 92-98 |
+| Sessions | session list, --session \<name\> | 100-108 |
+| Tabs | tab list/new/close/\<index\> | 110-117 |
+| Browser settings | set viewport/device/media | 119-125 |
+| Global options | --session, --headed, --json, --full | 127-135 |
+
+## Key Pattern: Screenshot + Upload to Miro
+
+```bash
+agent-browser open <url>
+agent-browser wait 1000          # always wait after page load
+agent-browser screenshot /tmp/out.png
+# then use miroctl to upload
+```
+
+## Essential Rules
+
+- Always `wait 1000` after `open` before taking screenshots
+- Use `snapshot -i` to get interactive element refs (@e1, @e2...) for click/fill
+- Binary at `~/.bun/bin/agent-browser`

--- a/skills/miro-agent/reference/agent-browser.md
+++ b/skills/miro-agent/reference/agent-browser.md
@@ -22,6 +22,7 @@ agent-browser pdf /tmp/page.pdf                # Save as PDF
 ```
 
 **Always wait after page load before screenshotting:**
+
 ```bash
 agent-browser open <url>
 agent-browser wait 1000        # Wait 1 second for animations/transitions
@@ -41,6 +42,7 @@ agent-browser snapshot -s "#main-content" # Scope to selector
 ```
 
 Use refs from snapshot in subsequent commands:
+
 ```bash
 agent-browser click @e5
 agent-browser fill @e12 "text"
@@ -126,12 +128,12 @@ agent-browser set media [dark|light]
 
 ## Global Options
 
-| Flag | Description |
-|------|-------------|
-| `--session <name>` | Use specific browser session |
-| `--headed` | Run in headed mode (visible browser) |
-| `--json` | Output as JSON |
-| `--full, -f` | Full page capture (screenshots/pdf) |
+| Flag               | Description                          |
+| ------------------ | ------------------------------------ |
+| `--session <name>` | Use specific browser session         |
+| `--headed`         | Run in headed mode (visible browser) |
+| `--json`           | Output as JSON                       |
+| `--full, -f`       | Full page capture (screenshots/pdf)  |
 
 ## Common Pattern: Screenshot + Upload to Miro
 
@@ -144,9 +146,4 @@ agent-browser screenshot /tmp/capture.png
 # 2. Upload to board (use miroctl)
 IMG_ID=$(miroctl images create-image-item-using-local-file \
   --board-id $BID --file /tmp/capture.png | jq -r '.id')
-
-# 3. Move to frame (wait for API)
-sleep 2
-miroctl items update --board-id $BID --item-id $IMG_ID \
-  --data '{"parent":{"id":"FRAME_ID"}}'
 ```

--- a/skills/miro-agent/reference/agent-browser.md
+++ b/skills/miro-agent/reference/agent-browser.md
@@ -1,0 +1,152 @@
+# agent-browser CLI Reference
+
+Headless browser automation for AI agents. Binary at `~/.bun/bin/agent-browser`.
+
+## Navigation
+
+```bash
+agent-browser open <url>           # Navigate to URL
+agent-browser back                 # Go back
+agent-browser forward              # Go forward
+agent-browser reload               # Reload page
+agent-browser close                # Close browser
+```
+
+## Screenshots & PDF
+
+```bash
+agent-browser screenshot                       # Base64 to stdout
+agent-browser screenshot /tmp/page.png         # Save to file
+agent-browser screenshot /tmp/full.png --full  # Full page capture
+agent-browser pdf /tmp/page.pdf                # Save as PDF
+```
+
+**Always wait after page load before screenshotting:**
+```bash
+agent-browser open <url>
+agent-browser wait 1000        # Wait 1 second for animations/transitions
+agent-browser screenshot /tmp/out.png
+```
+
+## Accessibility Snapshot
+
+Returns an accessibility tree with element refs (`@e1`, `@e2`, etc.) for AI reasoning:
+
+```bash
+agent-browser snapshot                    # Full tree
+agent-browser snapshot -i                 # Interactive elements only
+agent-browser snapshot -c                 # Compact (remove empty nodes)
+agent-browser snapshot -d 5               # Limit depth
+agent-browser snapshot -s "#main-content" # Scope to selector
+```
+
+Use refs from snapshot in subsequent commands:
+```bash
+agent-browser click @e5
+agent-browser fill @e12 "text"
+```
+
+## Interaction
+
+```bash
+agent-browser click <selector>           # Click element (or @ref)
+agent-browser dblclick <selector>        # Double-click
+agent-browser type <selector> <text>     # Type into element (appends)
+agent-browser fill <selector> <text>     # Clear and fill
+agent-browser press <key>                # Press key (Enter, Tab, Control+a)
+agent-browser hover <selector>           # Hover element
+agent-browser check <selector>           # Check checkbox
+agent-browser uncheck <selector>         # Uncheck checkbox
+agent-browser select <selector> <val>    # Select dropdown option
+agent-browser scroll <direction> [px]    # Scroll (up/down/left/right)
+agent-browser upload <selector> <files>  # Upload files
+agent-browser wait <selector|ms>         # Wait for element or time
+```
+
+## Semantic Find
+
+Find elements by semantic attributes and perform actions:
+
+```bash
+agent-browser find role <value> [action] [text]
+agent-browser find text <value> [action] [text]
+agent-browser find label <value> [action] [text]
+agent-browser find placeholder <value> [action] [text]
+agent-browser find testid <value> [action] [text]
+```
+
+Example: `agent-browser find role button click` — finds a button and clicks it.
+
+## Get Information
+
+```bash
+agent-browser get text [selector]        # Get text content
+agent-browser get html [selector]        # Get HTML content
+agent-browser get value [selector]       # Get input value
+agent-browser get attr <name> [selector] # Get attribute
+agent-browser get title                  # Get page title
+agent-browser get url                    # Get current URL
+agent-browser get count <selector>       # Count matching elements
+```
+
+## JavaScript Execution
+
+```bash
+agent-browser eval "document.title"
+agent-browser eval "document.querySelectorAll('a').length"
+agent-browser eval "JSON.stringify([...document.querySelectorAll('nav a')].map(a => ({href: a.href, text: a.textContent})))"
+```
+
+## Sessions
+
+Sessions persist browser state across commands:
+
+```bash
+agent-browser session                    # Show current session
+agent-browser session list               # List all sessions
+agent-browser --session <name> open <url>  # Use named session
+```
+
+## Tabs
+
+```bash
+agent-browser tab list                   # List open tabs
+agent-browser tab new [url]              # Open new tab
+agent-browser tab close [index]          # Close tab
+agent-browser tab <index>               # Switch to tab
+```
+
+## Browser Settings
+
+```bash
+agent-browser set viewport <width> <height>
+agent-browser set device <name>
+agent-browser set media [dark|light]
+```
+
+## Global Options
+
+| Flag | Description |
+|------|-------------|
+| `--session <name>` | Use specific browser session |
+| `--headed` | Run in headed mode (visible browser) |
+| `--json` | Output as JSON |
+| `--full, -f` | Full page capture (screenshots/pdf) |
+
+## Common Pattern: Screenshot + Upload to Miro
+
+```bash
+# 1. Capture
+agent-browser open http://localhost:3000
+agent-browser wait 1000
+agent-browser screenshot /tmp/capture.png
+
+# 2. Upload to board (use miroctl)
+IMG_ID=$(miroctl images create-image-item-using-local-file \
+  --board-id $BID --file /tmp/capture.png | jq -r '.id')
+
+# 3. Move to frame (wait for API)
+sleep 2
+miroctl items update --board-id $BID --item-id $IMG_ID \
+  --data '{"parent":{"id":"FRAME_ID"}}'
+```

--- a/skills/miro-agent/reference/miro-mcp-quick.md
+++ b/skills/miro-agent/reference/miro-mcp-quick.md
@@ -1,0 +1,32 @@
+# Miro MCP — Quick Reference
+
+Full reference: [reference/miro-mcp.md](miro-mcp.md)
+
+## Tool Index
+
+| Tool | Purpose | Full ref lines |
+|------|---------|---------------|
+| context_explore | Discover board structure (frames, docs, tables, diagrams) | 23-31 |
+| context_get | AI-powered content extraction from specific items | 33-47 |
+| board_list_items | List/filter items, scope to frame | 49-63 |
+| doc_create | Create markdown document on board | 65-80 |
+| doc_get | Read document content + version | 82-90 |
+| doc_update | Edit document via find-and-replace | 92-106 |
+| diagram_get_dsl | Get DSL format spec (call before diagram_create) | 108-121 |
+| diagram_create | Create diagram from DSL text | 123-139 |
+| table_create | Create table with text/select columns | 141-165 |
+| table_list_rows | Read/filter table rows | 167-181 |
+| table_sync_rows | Add or update table rows (upsert) | 183-203 |
+| image_get_data | Get image content (base64) | 205-211 |
+| image_get_url | Get image download URL | 213-219 |
+
+## Essential Patterns
+
+- All tools accept full Miro board URLs — board_id and item_id auto-extracted from `moveToWidget`/`focusWidget` params
+- Always call `doc_get` before `doc_update` (exact text match required)
+- Always call `diagram_get_dsl` before `diagram_create` (once per type per session)
+- Diagram types: `flowchart`, `uml_class`, `uml_sequence`, `entity_relationship` — no mindmap
+- Coordinates: center (0,0), +X right, +Y down
+- Spacing: diagrams 2000–3000, tables 1500–2000, docs 500–1000 apart
+- Use `parent_id` to place items inside frames
+- Use `key_column` in `table_sync_rows` for idempotent upserts

--- a/skills/miro-agent/reference/miro-mcp.md
+++ b/skills/miro-agent/reference/miro-mcp.md
@@ -1,0 +1,288 @@
+# Miro MCP Tools Reference
+
+All tools accept full Miro board URLs. Board ID and item ID are auto-extracted from URL query parameters (`moveToWidget`, `focusWidget`).
+
+## Contents
+
+- [context_explore](#context_explore) — discover board structure
+- [context_get](#context_get) — AI-powered content extraction
+- [board_list_items](#board_list_items) — list items with filtering
+- [doc_create](#doc_create) — create markdown document
+- [doc_get](#doc_get) — read document content
+- [doc_update](#doc_update) — edit document (find-and-replace)
+- [diagram_get_dsl](#diagram_get_dsl) — get diagram DSL format spec
+- [diagram_create](#diagram_create) — create diagram from DSL
+- [table_create](#table_create) — create table with columns
+- [table_list_rows](#table_list_rows) — read/filter table rows
+- [table_sync_rows](#table_sync_rows) — add or update rows
+- [image_get_data](#image_get_data) — get image data
+- [image_get_url](#image_get_url) — get image download URL
+
+---
+
+## context_explore
+
+Discover high-level items on a board: frames, documents, tables, prototypes, diagrams.
+
+```
+context_explore(board_url="https://miro.com/app/board/ID/")
+```
+
+Returns list of items with URLs and titles. Use these URLs with `context_get`.
+
+## context_get
+
+Get text content from a specific item. URL must include `moveToWidget` parameter.
+
+```
+context_get(item_url="https://miro.com/app/board/ID/?moveToWidget=ITEM_ID")
+```
+
+Returns vary by item type:
+- **Documents**: Markdown content
+- **Frames**: AI-generated summary of contents
+- **Tables**: Formatted table data
+- **Diagrams**: AI-generated description
+- **Prototype screens**: HTML markup
+- **Prototype containers**: AI-generated navigation map
+
+## board_list_items
+
+List items with type filtering and pagination. Can scope to a parent frame.
+
+```
+board_list_items(
+  board_id="ID",
+  limit=50,
+  item_type="sticky_note",    # optional filter
+  item_id="PARENT_FRAME_ID",  # optional: scope to frame (limit capped at 50)
+  cursor="next_page_cursor"   # optional: pagination
+)
+```
+
+**Item types:** `app_card`, `card`, `data_table_format`, `document`, `doc_format`, `embed`, `frame`, `image`, `preview`, `shape`, `sticky_note`, `text`
+
+## doc_create
+
+Create a markdown document on the board.
+
+```
+doc_create(
+  board_id="ID",
+  content="# Title\n\nMarkdown content...",
+  parent_id="FRAME_ID",  # optional: place inside frame
+  x=100,                  # optional: position
+  y=200                   # optional
+)
+```
+
+**Supported markdown:** headings (h1-h6), **bold**, *italic*, lists (ordered + unordered), [links](url).
+**Not supported:** code blocks, tables.
+
+## doc_get
+
+Read document content. Returns markdown and content version.
+
+```
+doc_get(board_id="ID", item_id="DOC_ID")
+```
+
+**Always call before `doc_update`** to get exact text for matching.
+
+## doc_update
+
+Edit document content via find-and-replace.
+
+```
+doc_update(
+  board_id="ID",
+  item_id="DOC_ID",
+  old_content="exact text to find",
+  new_content="replacement text",
+  replace_all=false       # optional: replace all occurrences
+)
+```
+
+**Requires exact text match.** Read the document first with `doc_get`.
+
+## diagram_get_dsl
+
+Get DSL format specification for a diagram type. **Must call before `diagram_create`.**
+
+```
+diagram_get_dsl(
+  board_id="ID",
+  diagram_type="flowchart"   # or: uml_class, uml_sequence, entity_relationship
+)
+```
+
+Returns rules, syntax, color guidelines, and examples. Only needed once per diagram type per session.
+
+**Note:** Only `flowchart`, `uml_class`, `uml_sequence`, and `entity_relationship` are supported. Mindmap uses a separate backend API not exposed through MCP tools.
+
+## diagram_create
+
+Create a diagram from DSL text. Requires prior call to `diagram_get_dsl`.
+
+```
+diagram_create(
+  board_id="ID",
+  diagram_type="flowchart",
+  title="User Journey",
+  diagram_dsl="<DSL text following the spec>",
+  parent_id="FRAME_ID",  # optional: place inside frame
+  x=0,                    # optional: position
+  y=0                     # optional
+)
+```
+
+**Diagram types:** `flowchart`, `uml_class`, `uml_sequence`, `entity_relationship`
+
+## table_create
+
+Create a table with typed columns.
+
+```
+table_create(
+  board_id="ID",
+  table_title="Issues",
+  columns=[
+    {"column_title": "Title", "column_type": "text"},
+    {"column_title": "Description", "column_type": "text"},
+    {
+      "column_title": "Status",
+      "column_type": "select",
+      "options": [
+        {"displayValue": "To Do", "color": "#4287f5"},
+        {"displayValue": "In Progress", "color": "#FFA500"},
+        {"displayValue": "Done", "color": "#00FF00"}
+      ]
+    }
+  ]
+)
+```
+
+Max 50 columns. Max 50 options per select column.
+
+## table_list_rows
+
+Read table rows with optional filtering by select column values.
+
+```
+table_list_rows(
+  board_id="ID",
+  item_id="TABLE_ID",
+  filter_by='{"Status": ["Open", "In Progress"]}',  # optional, select columns only
+  limit=10,
+  next_cursor="cursor"   # optional: pagination
+)
+```
+
+**Do not change `filter_by` when paginating with a cursor.** Start a new pagination sequence for different filters.
+
+## table_sync_rows
+
+Add or update table rows. Use `key_column` to match existing rows for update.
+
+```
+table_sync_rows(
+  board_id="ID",
+  item_id="TABLE_ID",
+  key_column="Title",    # optional: column to match for upsert
+  rows=[
+    {
+      "cells": [
+        {"columnTitle": "Title", "value": "Build feature X"},
+        {"columnTitle": "Status", "value": "In Progress"}
+      ]
+    }
+  ]
+)
+```
+
+Without `key_column`, all rows are inserted as new. With `key_column`, matching rows are updated.
+
+## image_get_data
+
+Get image data from a board item (base64 encoded).
+
+```
+image_get_data(board_id="ID", item_id="IMAGE_ID")
+```
+
+## image_get_url
+
+Get download URL for an image item.
+
+```
+image_get_url(board_id="ID", item_id="IMAGE_ID")
+```
+
+## Board Coordinates
+
+Board coordinates use a Cartesian system with center at `(0, 0)`. Positive X goes right, positive Y goes down.
+
+**Spacing recommendations** to prevent overlap when placing multiple items:
+
+| Content type | Spacing (units apart) |
+|-------------|----------------------|
+| Diagrams | 2000–3000 |
+| Tables | 1500–2000 |
+| Documents | 500–1000 |
+
+Use `parent_id` to place items inside frames — coordinates then become relative to the frame's top-left corner.
+
+## Best Practices
+
+### Diagrams
+- Be specific about elements and relationships in the DSL
+- Specify flow direction when relevant
+- Include decision points and conditions for flowcharts
+- Always call `diagram_get_dsl` first — follow the returned spec exactly
+
+### Documents
+- Structure with clear headings (h1 for title, h2 for sections)
+- Keep content focused and scannable
+- Use lists for multiple items
+- Include links to related resources
+- No code blocks or tables in doc content (not supported)
+
+### Tables
+- Choose meaningful, concise column names
+- Use select columns for status, priority, or category fields
+- Define visually distinct colors for select options
+- Use `key_column` in `table_sync_rows` for idempotent updates
+- Filter with `table_list_rows` before bulk updates to verify data
+
+### Context Extraction
+- Start with `context_explore` to discover board contents
+- Focus on specific frames when boards are large
+- Use `context_get` with item URLs (must include `moveToWidget` parameter)
+- For bulk item listing, use `board_list_items` with type filters
+
+## Doc Content Example
+
+A well-structured document for `doc_create`:
+
+```
+# Sprint Planning — Week 12
+
+## Goals
+- Complete user authentication module
+- Fix critical bugs from QA
+- Ship onboarding flow v2
+
+## Team Assignments
+1. **Alice** — Auth backend
+2. **Bob** — Frontend integration
+3. **Carol** — Bug fixes
+
+## Key Dates
+- *Monday*: Sprint kickoff
+- *Wednesday*: Mid-sprint review
+- *Friday*: Demo + retro
+
+## Resources
+- [Design specs](https://example.com/specs)
+- [API documentation](https://example.com/api)
+```

--- a/skills/miro-agent/reference/miroctl-quick.md
+++ b/skills/miro-agent/reference/miroctl-quick.md
@@ -1,0 +1,44 @@
+# miroctl CLI — Quick Reference
+
+Full reference: [reference/miroctl.md](miroctl.md)
+
+## Command Index
+
+| Command group | Operations | Full ref lines |
+|---------------|-----------|---------------|
+| Auth | set-token, status, revoke | 45-53 |
+| Boards | create, list, get, update, delete, copy | 55-64 |
+| Items (generic) | get-items, get-items-within-frame, get, update, delete | 66-84 |
+| Frames | create + update (two-step) | 86-101 |
+| Sticky notes | create | 103-111 |
+| Cards | create | 113-119 |
+| Shapes | create (with shape types list) | 121-134 |
+| Texts | create | 136-143 |
+| Images | upload local file, create from URL, move to frame | 145-161 |
+| Connectors | create | 163-171 |
+| Tags | create, attach, get-items-by-tag | 173-184 |
+| Groups | create, get-all, un-group | 186-192 |
+| Bulk operations | create-items, from file | 194-203 |
+| Board members | share, list | 205-213 |
+| Documents (file) | upload from device | 215-220 |
+| Embeds | create | 222-228 |
+| API escape hatch | api call &lt;operationId&gt; | 230-241 |
+| Pagination | --limit, --cursor, --all caveats | 243-260 |
+
+## CRUD Pattern
+
+`miroctl <type> create/get/update/delete --board-id $BID [--item-id $ID] [--data '{}']`
+
+Capture IDs: `| jq -r '.id'`
+
+## Global Options
+
+`--profile`, `--base-url`, `--token`, `--format` (json|raw|jsonl), `--all`, `-v`, `--retry-unsafe`
+
+## Key Gotchas
+
+- **Frames require two calls:** create (title only) then update (position, size, style)
+- **Sleep 2s after image upload** before moving to a frame
+- **`--all` breaks on cursor-based endpoints** — use `--limit` + `--cursor` instead
+- **`items get-items` minimum `--limit` is 10**
+- **Output is JSON** — parse with `jq`, capture IDs with `| jq -r '.id'`

--- a/skills/miro-agent/reference/miroctl.md
+++ b/skills/miro-agent/reference/miroctl.md
@@ -1,0 +1,270 @@
+# miroctl CLI Reference
+
+## Global Options
+
+Available on every command (per `miroctl --help`):
+
+| Flag | Description |
+|------|-------------|
+| `--profile <PROFILE>` | Config profile to use |
+| `--base-url <BASE_URL>` | Override API base URL |
+| `--token <TOKEN>` | Access token (overrides stored token) |
+| `--format <FORMAT>` | Output format: json, raw, jsonl (default: json) |
+| `--all` | Fetch all pages (pagination) — see Pagination section for caveats |
+| `-v, --verbose` | Enable verbose output |
+| `--retry-unsafe` | Retry non-idempotent requests on failure |
+
+## Common Per-Command Options
+
+Present on most but not all commands:
+
+| Flag | Description |
+|------|-------------|
+| `--board-id <ID>` | Board ID (required for most commands, not on `boards create`, `boards list`, `auth`, `config`) |
+| `--item-id <ID>` | Item ID (for get/update/delete operations) |
+| `--data '<json>'` | Request body as JSON string or `@file.json` (for create/update operations) |
+| `--file <path>` | File to upload (multipart operations only) |
+| `--limit <n>` | Items per page (list commands only) |
+| `--cursor <cursor>` | Pagination cursor (cursor-based list commands only) |
+
+**Note:** `--path key=value` syntax is only for `miroctl api call` (the escape hatch). All other commands use named flags like `--board-id`, `--item-id`, etc.
+
+## CRUD Pattern
+
+All item types follow the same structure:
+
+```bash
+miroctl <type> create --board-id $BID --data '{ ... }'
+miroctl <type> get    --board-id $BID --item-id $ITEM_ID
+miroctl <type> update --board-id $BID --item-id $ITEM_ID --data '{ ... }'
+miroctl <type> delete --board-id $BID --item-id $ITEM_ID
+```
+
+**Capture IDs from create responses:** `| jq -r '.id'`
+
+## Auth
+
+```bash
+miroctl auth status                # Check if token is stored
+miroctl auth set-token <TOKEN>     # Store token for active profile
+miroctl auth revoke                # Revoke and remove token
+```
+
+Token resolution order: `--token` flag > `MIRO_ACCESS_TOKEN` env var > stored token.
+
+## Boards
+
+```bash
+miroctl boards create --data '{"name":"Sprint 12","description":"Week 12 planning"}'
+miroctl boards list --all                    # List all boards (paginated)
+miroctl boards get --board-id $BID
+miroctl boards update-board --board-id $BID --data '{"name":"New Name"}'
+miroctl boards delete --board-id $BID
+miroctl boards copy-board --board-id $BID
+```
+
+## Items (Generic)
+
+Works across all item types:
+
+```bash
+miroctl items get-items --board-id $BID --limit 50
+miroctl items get-items-within-frame --board-id $BID --parent-item-id $FRAME_ID
+miroctl items get --board-id $BID --item-id $ITEM_ID
+miroctl items update --board-id $BID --item-id $ITEM_ID --data '{ ... }'
+miroctl items delete-item --board-id $BID --item-id $ITEM_ID
+```
+
+**Filter by type:** `miroctl items get-items --board-id $BID --type sticky_note --limit 50`
+
+**Move item to frame:**
+```bash
+miroctl items update --board-id $BID --item-id $ITEM_ID \
+  --data '{"parent":{"id":"FRAME_ID"},"position":{"x":100,"y":100}}'
+```
+
+## Frames
+
+**Two-step creation required.** Create only accepts title; position/size/style need a follow-up update.
+
+```bash
+# Step 1: Create (title only)
+FRAME_ID=$(miroctl frames create --board-id $BID \
+  --data '{"data":{"title":"My Frame"}}' | jq -r '.id')
+
+# Step 2: Set position, size, style
+miroctl frames update --board-id $BID --item-id $FRAME_ID --data '{
+  "position": {"x": 0, "y": 0},
+  "geometry": {"width": 1600, "height": 1200},
+  "style": {"fillColor": "#F5F6F8"}
+}'
+```
+
+## Sticky Notes
+
+```bash
+miroctl sticky-notes create --board-id $BID --data '{
+  "data": {"content": "Hello from miroctl!"},
+  "style": {"fillColor": "yellow"},
+  "position": {"x": 0, "y": 0}
+}'
+```
+
+## Cards
+
+```bash
+miroctl cards create --board-id $BID --data '{
+  "data": {"title": "Task title", "description": "Details here"}
+}'
+```
+
+## Shapes
+
+```bash
+miroctl shapes create --board-id $BID --data '{
+  "data": {"content": "Label", "shape": "rectangle"},
+  "style": {"fillColor": "#1e1e1e", "fontFamily": "roboto_mono", "fontSize": "12", "textAlign": "left", "color": "#ffffff"},
+  "geometry": {"width": 500, "height": 300},
+  "position": {"x": 100, "y": 100}
+}'
+```
+
+Shape types: `rectangle`, `round_rectangle`, `circle`, `triangle`, `rhombus`, `parallelogram`, `trapezoid`, `pentagon`, `hexagon`, `octagon`, `wedge_round_rectangle_callout`, `star`, `flow_chart_*`, etc.
+
+**Note:** `data.content` accepts HTML: `<p style="...">text</p>`.
+
+## Text Items
+
+```bash
+miroctl texts create --board-id $BID --data '{
+  "data": {"content": "Hello world"},
+  "position": {"x": 0, "y": 0}
+}'
+```
+
+## Images
+
+```bash
+# Upload from local file
+IMG_ID=$(miroctl images create-image-item-using-local-file \
+  --board-id $BID --file ./screenshot.png | jq -r '.id')
+
+# Create from URL
+miroctl images create-image-item-using-url --board-id $BID --data '{
+  "data": {"url": "https://example.com/image.png"}
+}'
+
+# IMPORTANT: sleep 2 seconds before moving uploaded images to a frame
+sleep 2
+miroctl items update --board-id $BID --item-id $IMG_ID \
+  --data '{"parent":{"id":"FRAME_ID"}}'
+```
+
+## Connectors
+
+```bash
+miroctl connectors create --board-id $BID --data '{
+  "startItem": {"id": "ITEM_ID_1"},
+  "endItem": {"id": "ITEM_ID_2"},
+  "style": {"strokeColor": "#000000"}
+}'
+```
+
+## Tags
+
+```bash
+# Create a tag
+TAG_ID=$(miroctl tags create --board-id $BID --data '{"title":"priority","fillColor":"red"}' | jq -r '.id')
+
+# Attach to item
+miroctl tags attach --board-id $BID --item-id $ITEM_ID --tag-id $TAG_ID
+
+# Find items by tag
+miroctl tags get-items-by-tag --board-id $BID --tag-id $TAG_ID
+```
+
+## Groups
+
+```bash
+miroctl groups create --board-id $BID --data '{"items":["ITEM_ID_1","ITEM_ID_2"]}'
+miroctl groups get-all-groups --board-id $BID
+miroctl groups un-group --board-id $BID --group-id $GROUP_ID
+```
+
+## Bulk Operations
+
+```bash
+# From inline JSON
+miroctl bulk-operations create-items --board-id $BID --data '[...]'
+
+# From file
+miroctl bulk-operations create-items-in-bulk-using-file-from-device \
+  --board-id $BID --file ./items.json
+```
+
+## Board Members
+
+```bash
+miroctl board-members share --board-id $BID --data '{
+  "emails": ["alice@company.com"],
+  "role": "commenter"
+}'
+miroctl board-members list --board-id $BID
+```
+
+## Documents (File Upload)
+
+```bash
+miroctl documents create-document-item-using-file-from-device \
+  --board-id $BID --file ./report.pdf
+```
+
+## Embeds
+
+```bash
+miroctl embeds create --board-id $BID --data '{
+  "data": {"url": "https://example.com"}
+}'
+```
+
+## API Escape Hatch
+
+Call any Miro API operation by operationId. This is the **only** command that uses `--path key=value`:
+
+```bash
+miroctl api call <OPERATION_ID> \
+  --path board_id=abc \
+  --query limit=5 \
+  --data '{"key":"value"}'
+```
+
+If you pass an unknown operationId, all available IDs are printed.
+
+## Pagination
+
+**Cursor-based endpoints** (items, connectors, etc.): Use `--limit` with manual `--cursor` pagination. Do **not** use `--all` — it has a cursor double-encoding bug that causes 400 errors on page 2+.
+
+**Offset-based endpoints** (boards list, tags get-items-by-tag): `--all` works correctly.
+
+**Minimum limit:** `items get-items` requires `--limit` >= 10. The API rejects lower values.
+
+```bash
+# Cursor-based: manual pagination
+miroctl items get-items --board-id $BID --limit 50
+
+# Next page (use cursor from previous response)
+miroctl items get-items --board-id $BID --limit 50 --cursor "<cursor_value>"
+
+# Offset-based: --all is safe
+miroctl boards list --all
+```
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | CLI usage error |
+| 3 | Auth error (401/403) — token missing or expired |
+| 4 | Network/timeout error |
+| 5 | Server error or unexpected response |

--- a/skills/miro-agent/reference/tool-selection.md
+++ b/skills/miro-agent/reference/tool-selection.md
@@ -1,0 +1,129 @@
+# Tool Selection Details
+
+## Core Principle
+
+- **MCP** for content intelligence — anything that benefits from structured input/output or AI understanding
+- **miroctl** for API operations — anything MCP can't do, plus fallback when MCP fails
+- **agent-browser** for visual capture — screenshots, web interaction, DOM inspection
+
+## Overlap Resolution
+
+Several operations can be done with either MCP or CLI. Use these rules:
+
+### Reading Board Items
+
+| Approach | Returns | When to use |
+|----------|---------|-------------|
+| MCP `context_explore` | Frames, docs, tables, diagrams with URLs and titles | First exploration of a board — understand what's there |
+| MCP `context_get` | AI summaries (frames), markdown (docs), HTML (prototypes), formatted data (tables) | Need to understand content semantically |
+| MCP `board_list_items` | Structured item list with type filtering | Need items of a specific type, or items within a frame |
+| CLI `items get-items --board-id ID --limit 50` | Raw JSON with all fields (position, geometry, style, metadata) | Need exact coordinates, styles, or metadata MCP doesn't expose |
+| CLI `items get-items-within-frame --board-id ID --parent-item-id FRAME_ID` | Raw JSON of items inside a frame | Same as above, scoped to a frame |
+
+**Default: MCP first.** It gives more useful context. Fall back to CLI when you need raw field data or MCP is unavailable.
+
+### Reading Documents
+
+MCP `doc_get` returns markdown content. CLI `items get` returns only metadata (type, position, dimensions) — not the document text. **Always use MCP for reading documents.**
+
+### Creating Content on a Board
+
+| Content type | Only option | Notes |
+|-------------|-------------|-------|
+| Documents | MCP `doc_create` | Accepts markdown, supports `parent_id` for frame placement |
+| Diagrams | MCP `diagram_get_dsl` + `diagram_create` | No CLI equivalent |
+| Tables | MCP `table_create` + `table_sync_rows` | No CLI equivalent |
+| Frames | CLI `frames create` + `frames update` | MCP cannot create frames |
+| Shapes | CLI `shapes create` | MCP cannot create shapes |
+| Sticky notes | CLI `sticky-notes create` | MCP cannot create sticky notes |
+| Text items | CLI `texts create` | MCP cannot create text items |
+| Cards | CLI `cards create` | MCP cannot create cards |
+| Images | CLI `images create-image-item-using-local-file` | MCP can only read images |
+| Connectors | CLI `connectors create` | MCP cannot create connectors |
+
+There is no overlap for creation — each content type has exactly one tool that can create it.
+
+## Fallback Chains
+
+When MCP fails, fall back to CLI where possible:
+
+```
+MCP context_explore fails
+  → CLI: miroctl items get-items --board-id ID --limit 50
+    Parse JSON to find frames, docs, tables by type field
+
+MCP board_list_items fails
+  → CLI: miroctl items get-items --board-id ID --limit 50
+    Or for frame scope: miroctl items get-items-within-frame --board-id ID --parent-item-id FRAME_ID
+
+MCP doc_get fails
+  → No CLI equivalent for document content. Inform user.
+
+MCP doc_create fails
+  → No CLI equivalent for structured docs. Inform user.
+
+MCP table_create / table_list_rows / table_sync_rows fails
+  → No CLI equivalent. Inform user.
+
+MCP diagram_create fails
+  → No CLI equivalent. Inform user.
+
+MCP image_get_data fails
+  → CLI: miroctl images get --board-id ID --item-id ITEM_ID
+    Returns metadata only, not image data. Limited fallback.
+```
+
+**Rule:** If MCP fails for a read operation, try CLI. If MCP fails for a create operation that has no CLI equivalent, inform the user that MCP access is required.
+
+## Multi-Tool Chain Patterns
+
+### Screenshot → Board
+
+Capture a webpage and place it on a board:
+
+```
+1. agent-browser open <url>
+2. agent-browser wait 1000
+3. agent-browser screenshot /tmp/capture.png
+4. IMG_ID=$(miroctl images create-image-item-using-local-file --board-id $BID --file /tmp/capture.png | jq -r '.id')
+5. sleep 2    # API needs time before item can be moved
+6. miroctl items update --board-id $BID --item-id $IMG_ID --data '{"parent":{"id":"FRAME_ID"}}'
+```
+
+### Frame with Mixed Content
+
+Create a frame and populate it with different content types:
+
+```
+1. FRAME_ID=$(miroctl frames create --board-id $BID --data '{"data":{"title":"My Frame"}}' | jq -r '.id')
+2. miroctl frames update --board-id $BID --item-id $FRAME_ID --data '{"position":{"x":0,"y":0},"geometry":{"width":1600,"height":1200},"style":{"fillColor":"#F5F6F8"}}'
+3. MCP doc_create with parent_id=$FRAME_ID    # doc goes inside frame
+4. MCP diagram_create with parent_id=$FRAME_ID  # diagram goes inside frame
+5. Upload image via CLI, sleep 2, then items update with parent
+```
+
+MCP items accept `parent_id` directly. CLI items must be created first, then moved with `items update`.
+
+### Board Population from External Data
+
+Read external data and populate a board:
+
+```
+1. miroctl frames create + update    # create container frame
+2. MCP table_create                  # create table structure
+3. MCP table_sync_rows               # populate rows
+4. MCP doc_create                    # add summary document
+5. MCP diagram_create                # add architectural diagram
+```
+
+### Board → Code Implementation
+
+Read board content and use it to drive code changes:
+
+```
+1. MCP context_explore               # discover board structure
+2. MCP context_get on relevant items  # read content in detail
+3. MCP board_list_items with filters  # get specific items (e.g., stickies in a frame)
+4. Use extracted content to write code
+5. Post results back to board (screenshot, doc, table update)
+```

--- a/skills/miro-agent/scripts/preflight.sh
+++ b/skills/miro-agent/scripts/preflight.sh
@@ -16,6 +16,10 @@ json_result() {
   },
   "agent_browser": {
     "installed": $4
+  },
+  "mcp": {
+    "checked": false,
+    "action_required": "MUST call board_list_items(board_id=<any_board_url>, limit=1) now — this is the ONLY valid MCP test. Do NOT use context_explore (it uses narrower scopes and gives false positives). If board_list_items fails with 'Board access denied': user must remove and re-add the MCP server to re-authorize with full scopes. Any other failure: see SKILL.md preflight step 2. Do NOT proceed until board_list_items succeeds."
   }
 }
 EOF
@@ -57,6 +61,9 @@ elif [ -x "$HOME/.bun/bin/agent-browser" ]; then
 else
   echo "agent-browser: not installed" >&2
 fi
+
+# --- MCP ---
+echo "mcp: cannot verify from bash — agent MUST test via MCP tool call before proceeding" >&2
 
 # --- Output ---
 json_result "$miroctl_installed" "$miroctl_authenticated" "$miroctl_token_valid" "$agent_browser_installed"

--- a/skills/miro-agent/scripts/preflight.sh
+++ b/skills/miro-agent/scripts/preflight.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Miro skill preflight check
+# Checks miroctl (installed + authenticated) and agent-browser (installed).
+# MCP must be checked separately via MCP tool calls.
+# Outputs JSON to stdout. All diagnostics go to stderr.
+
+set -euo pipefail
+
+json_result() {
+  cat <<EOF
+{
+  "miroctl": {
+    "installed": $1,
+    "authenticated": $2,
+    "token_valid": $3
+  },
+  "agent_browser": {
+    "installed": $4
+  }
+}
+EOF
+}
+
+# --- miroctl ---
+miroctl_installed=false
+miroctl_authenticated=false
+miroctl_token_valid=false
+
+if command -v miroctl &>/dev/null; then
+  miroctl_installed=true
+
+  # Check if a token is stored (or env var set)
+  if miroctl auth status &>/dev/null; then
+    miroctl_authenticated=true
+
+    # Validate token is not expired by making a lightweight API call
+    if miroctl tokens list &>/dev/null; then
+      miroctl_token_valid=true
+    else
+      echo "miroctl: token stored but expired or invalid" >&2
+    fi
+  else
+    echo "miroctl: no token configured" >&2
+  fi
+else
+  echo "miroctl: not installed" >&2
+fi
+
+# --- agent-browser ---
+agent_browser_installed=false
+
+if command -v agent-browser &>/dev/null; then
+  agent_browser_installed=true
+elif [ -x "$HOME/.bun/bin/agent-browser" ]; then
+  agent_browser_installed=true
+  echo "agent-browser: found at ~/.bun/bin/agent-browser but not in PATH" >&2
+else
+  echo "agent-browser: not installed" >&2
+fi
+
+# --- Output ---
+json_result "$miroctl_installed" "$miroctl_authenticated" "$miroctl_token_valid" "$agent_browser_installed"

--- a/skills/miro-agent/scripts/test-playbook.md
+++ b/skills/miro-agent/scripts/test-playbook.md
@@ -1,0 +1,400 @@
+# miro-agent Test Playbook
+
+Run this playbook to validate the skill end-to-end. Creates a fresh board, tests CLI and MCP operations, then cleans up.
+
+---
+
+## Setup
+
+**Always create a fresh board for testing. Never reuse an existing board.**
+
+```bash
+BOARD_ID=$(miroctl boards create --data '{"name":"skill-test-'$(date +%s)'"}' | jq -r '.id')
+```
+
+Print the board URL and continue immediately — do not wait for user confirmation:
+
+```
+Test board created: https://miro.com/app/board/$BOARD_ID
+```
+
+Run preflight:
+
+```bash
+bash scripts/preflight.sh
+```
+
+Verify MCP with a lightweight call:
+
+```
+board_list_items(board_id="https://miro.com/app/board/$BOARD_ID", limit=10)
+```
+
+---
+
+## Part 1: CLI Tests
+
+Run these commands sequentially. Each should exit 0 and return valid JSON unless noted.
+
+**Important:** Always use the `$BOARD_ID` variable — never inline literal board IDs. Board IDs end with `=` which gets dropped without proper quoting. All commands below use `"$BOARD_ID"` (double-quoted) which handles this correctly.
+
+### 1.1 Frame (two-step creation)
+
+```bash
+FRAME_ID=$(miroctl frames create --board-id "$BOARD_ID" \
+  --data '{"data":{"title":"Test Frame"}}' | jq -r '.id')
+
+miroctl frames update --board-id "$BOARD_ID" --item-id $FRAME_ID --data '{
+  "position":{"x":0,"y":0},
+  "geometry":{"width":1600,"height":1200},
+  "style":{"fillColor":"#F5F6F8"}
+}'
+```
+
+**Verify:** Response has `.geometry.width` = 1600, `.position.x` = 0.
+
+### 1.2 Sticky note
+
+```bash
+STICKY_ID=$(miroctl sticky-notes create --board-id "$BOARD_ID" --data '{
+  "data":{"content":"Test Sticky"},
+  "style":{"fillColor":"yellow"},
+  "position":{"x":100,"y":100}
+}' | jq -r '.id')
+```
+
+**Verify:** `.type` = `sticky_note`, `.data.content` = "Test Sticky".
+
+### 1.3 Shape
+
+```bash
+SHAPE_COLOR=$(printf '#%06X' $((RANDOM * RANDOM % 16777216)))
+
+SHAPE_ID=$(miroctl shapes create --board-id "$BOARD_ID" --data "{
+  \"data\":{\"content\":\"Test Shape\",\"shape\":\"rectangle\"},
+  \"style\":{\"fillColor\":\"$SHAPE_COLOR\"},
+  \"geometry\":{\"width\":200,\"height\":100},
+  \"position\":{\"x\":300,\"y\":100}
+}" | jq -r '.id')
+```
+
+**Verify:** `.data.shape` = `rectangle`.
+
+### 1.4 Text
+
+```bash
+TEXT_ID=$(miroctl texts create --board-id "$BOARD_ID" --data '{
+  "data":{"content":"Test Text"},
+  "position":{"x":500,"y":100}
+}' | jq -r '.id')
+```
+
+### 1.5 Card
+
+```bash
+CARD_ID=$(miroctl cards create --board-id "$BOARD_ID" --data '{
+  "data":{"title":"Test Card"}
+}' | jq -r '.id')
+```
+
+### 1.6 Connector
+
+```bash
+# Note: --data uses double quotes for variable expansion. Keep --board-id
+# as a separate quoted arg — do not inline the board ID into the JSON string.
+miroctl connectors create --board-id "$BOARD_ID" --data "{
+  \"startItem\":{\"id\":\"$STICKY_ID\"},
+  \"endItem\":{\"id\":\"$SHAPE_ID\"}
+}"
+```
+
+**Verify:** `.startItem.id` = STICKY_ID, `.endItem.id` = SHAPE_ID.
+
+### 1.7 Tag + attach
+
+```bash
+TAG_ID=$(miroctl tags create --board-id "$BOARD_ID" \
+  --data '{"title":"test-tag","fillColor":"red"}' | jq -r '.id')
+
+miroctl tags attach --board-id "$BOARD_ID" --item-id $STICKY_ID --tag-id $TAG_ID
+```
+
+**Verify:** Both commands exit 0.
+
+### 1.8 Image upload
+
+```bash
+# Generate a valid 128x128 red PNG
+python3 -c "
+import struct, zlib
+w=h=128; raw=b''.join(b'\x00'+b'\xff\x00\x00\xff'*w for _ in range(h))
+def c(t,d): return struct.pack('>I',len(d))+t+d+struct.pack('>I',zlib.crc32(t+d)&0xffffffff)
+open('/tmp/miro-test.png','wb').write(b'\x89PNG\r\n\x1a\n'+c(b'IHDR',struct.pack('>IIBBBBB',w,h,8,6,0,0,0))+c(b'IDAT',zlib.compress(raw))+c(b'IEND',b''))
+"
+
+IMG_ID=$(miroctl images create-image-item-using-local-file \
+  --board-id "$BOARD_ID" --file /tmp/miro-test.png | jq -r '.id')
+```
+
+**Verify:** `.type` = `image`, `.id` is captured.
+
+### 1.9 Embed
+
+```bash
+EMBED_ID=$(miroctl embeds create --board-id "$BOARD_ID" --data '{
+  "data":{"url":"https://info.cern.ch/hypertext/WWW/TheProject.html"},
+  "position":{"x":700,"y":100}
+}' | jq -r '.id')
+```
+
+**Verify:** `.type` = `embed`, `.data.url` contains info.cern.ch.
+
+### 1.10 Screenshot + upload
+
+```bash
+agent-browser open "https://miro.com"
+agent-browser screenshot /tmp/miro-screenshot.png
+
+SCREENSHOT_ID=$(miroctl images create-image-item-using-local-file \
+  --board-id "$BOARD_ID" --file /tmp/miro-screenshot.png | jq -r '.id')
+```
+
+**Verify:** Screenshot file exists, upload returns `.type` = `image`.
+
+### 1.11 Image from URL
+
+```bash
+URL_IMG_ID=$(miroctl images create-image-item-using-url --board-id "$BOARD_ID" --data '{
+  "data":{"url":"https://picsum.photos/200"},
+  "position":{"x":900,"y":100}
+}' | jq -r '.id')
+```
+
+**Verify:** `.type` = `image`.
+
+### 1.12 Document file upload
+
+```bash
+printf '%%PDF-1.0\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n3 0 obj<</Type/Page/MediaBox[0 0 612 792]/Parent 2 0 R>>endobj\nxref\n0 4\n0000000000 65535 f \n0000000009 00000 n \n0000000058 00000 n \n0000000115 00000 n \ntrailer<</Size 4/Root 1 0 R>>\nstartxref\n190\n%%%%EOF' > /tmp/miro-test.pdf
+
+DOC_FILE_ID=$(miroctl documents create-document-item-using-file-from-device \
+  --board-id "$BOARD_ID" --file /tmp/miro-test.pdf | jq -r '.id')
+```
+
+**Verify:** `.type` = `document`.
+
+### 1.13 Item delete
+
+```bash
+miroctl items delete-item --board-id "$BOARD_ID" --item-id $TEXT_ID
+```
+
+**Verify:** Exit code 0. Confirm by fetching the item — should return 404.
+
+### 1.14 List items
+
+```bash
+miroctl items get-items --board-id "$BOARD_ID" --limit 10
+```
+
+**Verify:** `.data` array contains items.
+
+### 1.15 Filter by type
+
+```bash
+miroctl items get-items --board-id "$BOARD_ID" --limit 10 --type sticky_note
+```
+
+**Verify:** All items in `.data` have `.type` = `sticky_note`.
+
+### 1.16 Get specific item
+
+```bash
+miroctl items get --board-id "$BOARD_ID" --item-id $STICKY_ID
+```
+
+**Verify:** `.id` = STICKY_ID.
+
+### 1.17 Boards list (offset-based --all)
+
+```bash
+miroctl boards list --all
+```
+
+**Verify:** Exit code 0. This confirms `--all` works on offset-based endpoints.
+
+### 1.18 Minimum limit validation
+
+```bash
+miroctl items get-items --board-id "$BOARD_ID" --limit 5
+```
+
+**Verify:** Should **fail** with exit code 5 (400 error, minimum limit is 10).
+
+---
+
+## Part 2: MCP Tests
+
+Run these MCP tool calls against the same test board. Use the board URL: `https://miro.com/app/board/$BOARD_ID`
+
+### 2.1 context_explore
+
+```
+context_explore(board_url="https://miro.com/app/board/$BOARD_ID")
+```
+
+**Verify:** Returns list including the "Test Frame" frame.
+
+### 2.2 context_get
+
+```
+context_get(item_url="https://miro.com/app/board/$BOARD_ID/?moveToWidget=$FRAME_ID")
+```
+
+**Verify:** Returns AI summary mentioning the items inside the frame.
+
+### 2.3 board_list_items (filtered)
+
+```
+board_list_items(board_id="$BOARD_ID", limit=50, item_type="sticky_note")
+```
+
+**Verify:** Returns only sticky notes.
+
+### 2.4 doc_create
+
+```
+doc_create(
+  board_id="$BOARD_ID",
+  content="# Test Document\n\nThis is a **test** document.\n\n- Item one\n- Item two"
+)
+```
+
+**Verify:** Returns item with document content. Note the item ID for steps 2.5-2.6.
+
+### 2.5 doc_get
+
+```
+doc_get(board_id="$BOARD_ID", item_id="$DOC_ID")
+```
+
+**Verify:** Returns markdown content matching what was created.
+
+### 2.6 doc_update
+
+```
+doc_update(
+  board_id="$BOARD_ID",
+  item_id="$DOC_ID",
+  old_content="Item one",
+  new_content="Updated item"
+)
+```
+
+**Verify:** Success. Call `doc_get` again to confirm the change.
+
+### 2.7 diagram_get_dsl
+
+```
+diagram_get_dsl(board_id="$BOARD_ID", diagram_type="flowchart")
+```
+
+**Verify:** Returns DSL specification with rules, syntax, color guidelines, example.
+
+### 2.8 diagram_create
+
+```
+diagram_create(
+  board_id="$BOARD_ID",
+  diagram_type="flowchart",
+  title="Test Diagram",
+  diagram_dsl="<valid DSL from step 2.7>"
+)
+```
+
+**Verify:** Returns created diagram item.
+
+### 2.9 table_create
+
+```
+table_create(
+  board_id="$BOARD_ID",
+  table_title="Test Table",
+  columns=[
+    {"column_title": "Title", "column_type": "text"},
+    {"column_title": "Status", "column_type": "select", "options": [
+      {"displayValue": "Open", "color": "#4287f5"},
+      {"displayValue": "Done", "color": "#00FF00"}
+    ]}
+  ]
+)
+```
+
+**Verify:** Returns table item. Note the item ID.
+
+### 2.10 table_sync_rows
+
+```
+table_sync_rows(
+  board_id="$BOARD_ID",
+  item_id="$TABLE_ID",
+  rows=[{"cells": [
+    {"columnTitle": "Title", "value": "Test Row"},
+    {"columnTitle": "Status", "value": "Open"}
+  ]}]
+)
+```
+
+**Verify:** Row added successfully.
+
+### 2.11 table_list_rows
+
+```
+table_list_rows(
+  board_id="$BOARD_ID",
+  item_id="$TABLE_ID",
+  filter_by='{"Status": ["Open"]}',
+  limit=10
+)
+```
+
+**Verify:** Returns the row from step 2.10.
+
+### 2.12 image_get_data
+
+```
+image_get_data(board_id="$BOARD_ID", item_id="$IMG_ID")
+```
+
+**Verify:** Returns image data (the test PNG from Part 1).
+
+### 2.13 image_get_url
+
+```
+image_get_url(board_id="$BOARD_ID", item_id="$IMG_ID")
+```
+
+**Verify:** Returns a download URL.
+
+---
+
+## Cleanup
+
+```bash
+miroctl boards delete --board-id "$BOARD_ID"
+rm -f /tmp/miro-test.png /tmp/miro-screenshot.png /tmp/miro-test.pdf
+```
+
+---
+
+## What to Watch For
+
+- **Tool routing:** MCP for docs/diagrams/tables/context. CLI for frames/shapes/stickies/images. Agent should never mix these up.
+- **Quick ref usage:** Agent should load quick reference first, then read specific line ranges from full reference — not the entire full reference.
+- **Frame two-step:** Create then update with position/size/style.
+- **Sleep after upload:** 2 seconds before moving images to a frame.
+- **Board ID quoting:** Always quote `--board-id "$BOARD_ID"` — the trailing `=` in board IDs gets dropped by some shells without quotes.
+- **Board ID handling:** Full URLs to MCP tools. Extracted IDs to miroctl `--board-id`.
+- **`--all` caveat:** Works on `boards list` (offset). Breaks on `items get-items` (cursor).
+- **Minimum limit:** `items get-items` requires `--limit` >= 10.
+- **Fallback:** If MCP fails, agent should try CLI where possible and inform user otherwise.


### PR DESCRIPTION
## Summary

- Adds `skills/miro-agent/` — a skill that routes Miro board interactions to the optimal tool (MCP, miroctl CLI, or agent-browser)
- Includes full + quick references for all three tools, a preflight script, and a tool selection guide
- **Includes an end-to-end test playbook** (see below)

> DEPENDENCY: oAuth flow in CLI

## Files

| File | Purpose |
|------|---------|
| `SKILL.md` | Routing rules, preflight, tool matrix, gotchas, error handling |
| `agents.md` | Maintenance instructions for keeping the skill updated |
| `reference/miroctl.md` + `miroctl-quick.md` | CLI reference (full + index with line pointers) |
| `reference/miro-mcp.md` + `miro-mcp-quick.md` | MCP reference (full + index with line pointers) |
| `reference/agent-browser.md` + `agent-browser-quick.md` | Browser reference (full + index with line pointers) |
| `reference/tool-selection.md` | Overlap resolution and fallback chains |
| `scripts/preflight.sh` | Checks miroctl install/auth and agent-browser availability |
| `scripts/test-playbook.md` | End-to-end test suite |

## Test Playbook

The playbook (`scripts/test-playbook.md`) validates the skill end-to-end on a fresh board:

### Test Setup
Creates a temporary board via `miroctl boards create`, runs preflight, verifies MCP connectivity.

#### Part 1 — CLI tests (18 tests):
- Frame two-step creation (create + update for position/size/style)
- Sticky note, shape, text, card creation
- Connector between items
- Tag create + attach
- Image upload from local file
- Embed creation
- Screenshot capture via agent-browser + upload
- Image from URL
- Document file upload (PDF)
- Item deletion
- List/filter items by type
- Get specific item
- Boards list with `--all` (offset-based pagination)
- Minimum limit validation (`--limit 5` should fail with 400)

#### Part 2 — MCP tests (13 tests):
- `context_explore` — discover board structure
- `context_get` — AI summary of frame contents
- `board_list_items` — filtered by type
- `doc_create` / `doc_get` / `doc_update` — full document lifecycle
- `diagram_get_dsl` + `diagram_create` — flowchart creation
- `table_create` / `table_sync_rows` / `table_list_rows` — table lifecycle with filtering
- `image_get_data` / `image_get_url` — image retrieval

#### Cleanup:
Deletes the test board and temp files.

**What to watch for:** Tool routing correctness, quick ref usage (not loading full refs), frame two-step pattern, sleep after upload, board ID quoting, `--all` caveat on cursor-based endpoints, minimum limit enforcement, MCP→CLI fallback behavior.