### PR TITLE
fix(miro-tasks): fetch exactly one not-done task using status filter and limit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
       "description": "Track your coding progress on a Miro board. Automatically syncs todos and task status to visual cards.",
       "source": "./claude-plugins/miro-tasks",
       "category": "development",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "author": {
         "name": "Miro",
         "email": "support@miro.com"

--- a/claude-plugins/miro-tasks/.claude-plugin/plugin.json
+++ b/claude-plugins/miro-tasks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "miro-tasks",
   "description": "Track tasks on a Miro board",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": {
     "name": "Miro",
     "email": "support@miro.com"

--- a/claude-plugins/miro-tasks/scripts/hooks-stop.sh
+++ b/claude-plugins/miro-tasks/scripts/hooks-stop.sh
@@ -16,11 +16,27 @@ fi
 
 # Output block decision with reason
 # Note: Using heredoc-style message for clarity, then escaping for JSON
-reason="Get ONE incomplete task from the table and complete it: ${table_url}
-Use table_list_rows with filters to fetch tasks that are in progress or incomplete.
-- Completed statuses are typically named: Done, Completed, Finished, Closed, etc.
-- Pick any task with a different status (e.g., To Do, In Progress, Pending, etc.)
-When all tasks are complete, run ${CLAUDE_PLUGIN_ROOT}/scripts/command-disable.sh to disable tracking."
+reason="You MUST complete a task from this Miro table before stopping: ${table_url}
+
+Follow these steps exactly:
+
+STEP 1 - Discover columns:
+Call table_list_rows with board_id set to the table URL above and limit set to 1. No filter.
+From the response columns array, find the select-type column that represents task status (usually named Status but could vary).
+Read its selectOptions to get all possible status values.
+
+STEP 2 - Identify not-done values:
+From the selectOptions, classify each value as done or not-done.
+Done values are those indicating completion: Done, Completed, Finished, Closed (case-insensitive).
+All other values (To Do, In Progress, Pending, Open, Blocked, etc.) are not-done.
+
+STEP 3 - Fetch the first incomplete task:
+Call table_list_rows with board_id set to the table URL above, filter_by as a JSON object mapping the status column name to the array of not-done values, and limit set to 1.
+This returns the FIRST incomplete task in table order, which is the highest priority.
+
+STEP 4 - Handle the result:
+If the response total is 0, all tasks are done. Run ${CLAUDE_PLUGIN_ROOT}/scripts/command-disable.sh to disable tracking, then you may stop.
+If a task is returned, complete that specific task. Do not skip it or pick a different one."
 
 # Escape the reason for JSON (newlines to \n, quotes to \")
 escaped_reason=$(printf '%s' "$reason" | sed 's/"/\\"/g' | awk '{printf "%s\\n", $0}' | sed 's/\\n$//')

--- a/gemini-extensions/miro-tasks/gemini-extension.json
+++ b/gemini-extensions/miro-tasks/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "miro-tasks",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Track tasks on a Miro board"
 }

--- a/gemini-extensions/miro-tasks/scripts/hooks-stop.sh
+++ b/gemini-extensions/miro-tasks/scripts/hooks-stop.sh
@@ -16,11 +16,27 @@ fi
 
 # Output block decision with reason
 # Note: Using heredoc-style message for clarity, then escaping for JSON
-reason="Get ONE incomplete task from the table and complete it: ${table_url}
-Use table_list_rows with filters to fetch tasks that are in progress or incomplete.
-- Completed statuses are typically named: Done, Completed, Finished, Closed, etc.
-- Pick any task with a different status (e.g., To Do, In Progress, Pending, etc.)
-When all tasks are complete, run ${extensionPath}/scripts/command-disable.sh to disable tracking."
+reason="You MUST complete a task from this Miro table before stopping: ${table_url}
+
+Follow these steps exactly:
+
+STEP 1 - Discover columns:
+Call table_list_rows with board_id set to the table URL above and limit set to 1. No filter.
+From the response columns array, find the select-type column that represents task status (usually named Status but could vary).
+Read its selectOptions to get all possible status values.
+
+STEP 2 - Identify not-done values:
+From the selectOptions, classify each value as done or not-done.
+Done values are those indicating completion: Done, Completed, Finished, Closed (case-insensitive).
+All other values (To Do, In Progress, Pending, Open, Blocked, etc.) are not-done.
+
+STEP 3 - Fetch the first incomplete task:
+Call table_list_rows with board_id set to the table URL above, filter_by as a JSON object mapping the status column name to the array of not-done values, and limit set to 1.
+This returns the FIRST incomplete task in table order, which is the highest priority.
+
+STEP 4 - Handle the result:
+If the response total is 0, all tasks are done. Run ${extensionPath}/scripts/command-disable.sh to disable tracking, then you may stop.
+If a task is returned, complete that specific task. Do not skip it or pick a different one."
 
 # Escape the reason for JSON (newlines to \n, quotes to \")
 escaped_reason=$(printf '%s' "$reason" | sed 's/"/\\"/g' | awk '{printf "%s\\n", $0}' | sed 's/\\n$//')


### PR DESCRIPTION
## Summary

- Rewrote the Stop hook instructions to use `table_list_rows` with `filter_by` (status filtering) and `limit=1` to deterministically pull exactly one incomplete task
- The 4-step workflow discovers column metadata first, classifies status values, then fetches the first not-done row in table order (highest priority)
- When `total=0` (all tasks done), auto-disables tracking
- Bumped miro-tasks version to 1.0.2, regenerated Gemini extension

## Test plan

- [ ] Enable miro-tasks with `/miro-tasks:enable <table-url>` on a table with mixed done/not-done tasks
- [ ] Trigger Stop hook — verify Claude calls `table_list_rows` with `limit=1` twice (discovery + filtered fetch)
- [ ] Confirm the returned task is the first incomplete row in table order
- [ ] Mark all tasks done, trigger Stop again — verify auto-disable fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)