### PR TITLE
docs: single install method per client, avoid duplicate MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ This repo provides everything you need to connect AI tools to Miro:
 | **Claude Code** | Plugins |
 | **Gemini CLI** | Extensions |
 | **Kiro** | Power |
-| **Cursor** | Plugins |
 | **Agent Skills** | Skills |
-| **VSCode, Windsurf, etc.** | MCP Config |
+| **Cursor, VSCode, Windsurf, etc.** | MCP Config |
 
 ---
 
@@ -124,32 +123,9 @@ See [Agent Skills Overview](docs/agent-skills/overview.md) | [agentskills.io](ht
 </details>
 
 <details>
-<summary><strong>Cursor</strong></summary>
+<summary><strong>Other MCP Clients</strong> (Cursor, VSCode + Copilot, Windsurf, Lovable, Replit, etc.)</summary>
 
-**Marketplace** (recommended):
-1. In Cursor, run `/add-plugin` and search for "Miro"
-2. Or browse [cursor.com/marketplace](https://cursor.com/marketplace)
-
-**Local development** (not officially documented — [community workaround](https://forum.cursor.com/t/cursor-2-5-plugins/152124)):
-
-```bash
-git clone https://github.com/miroapp/miro-ai.git
-cp -r miro-ai/cursor-plugins/miro ~/.cursor/plugins/miro
-# Restart Cursor
-```
-
-> **Important:** If you previously added Miro MCP manually (via Settings > MCP Servers),
-> remove that entry — the plugin already manages the MCP connection for you.
-> See [Avoiding Duplicate Servers](#avoiding-duplicate-servers) for details.
-
-See [Cursor Plugins](docs/cursor/overview.md) for full documentation.
-
-</details>
-
-<details>
-<summary><strong>Other MCP Clients</strong> (VSCode + Copilot, Windsurf, Lovable, Replit, etc.)</summary>
-
-For clients that don't have a dedicated Miro plugin or extension, add to your MCP client configuration file:
+Add to your MCP client configuration file:
 
 ```json
 {
@@ -259,16 +235,6 @@ See the [Duplicate MCP Servers](https://developers.miro.com/docs/miro-mcp-server
 | miro-research | Research visualization |
 | miro-review | Code review workflows |
 
-### Cursor
-
-| Plugin | Description |
-|--------|-------------|
-| miro | Core MCP integration with 5 commands and skills |
-| miro-tasks | Task tracking with hooks and scripts |
-| miro-research | Research visualization with MCP |
-| miro-review | Code review workflows |
-| miro-spec | Design spec extraction |
-
 ### Agent Skills
 
 | Skill | Description |
@@ -303,7 +269,6 @@ See the [Duplicate MCP Servers](https://developers.miro.com/docs/miro-mcp-server
 ### Platform Guides
 - [Claude Code Plugins](docs/claude-code/overview.md)
 - [Gemini CLI Extension](docs/gemini-cli/overview.md)
-- [Cursor Plugins](docs/cursor/overview.md)
 - [Agent Skills](docs/agent-skills/overview.md)
 - [Kiro Powers](docs/kiro/overview.md)
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Optional plugins:
 /plugin install miro-review@miro-ai      # Code review workflows
 ```
 
-**Restart Claude Code** after installation. If you previously configured Miro MCP manually, [remove the duplicate](docs/troubleshooting.md#duplicate-mcp-servers) to avoid conflicts.
+**Restart Claude Code** after installation. If you previously configured Miro MCP manually, [remove the duplicate](docs/troubleshooting.md#duplicate-mcp-servers) to avoid conflicts — the plugin already manages the MCP connection for you.
 
 See [Claude Code Plugins](docs/claude-code/overview.md) for full documentation.
 
@@ -138,14 +138,18 @@ cp -r miro-ai/cursor-plugins/miro ~/.cursor/plugins/miro
 # Restart Cursor
 ```
 
+> **Important:** If you previously added Miro MCP manually (via Settings > MCP Servers),
+> remove that entry — the plugin already manages the MCP connection for you.
+> See [Avoiding Duplicate Servers](#avoiding-duplicate-servers).
+
 See [Cursor Plugins](docs/cursor/overview.md) for full documentation.
 
 </details>
 
 <details>
-<summary><strong>Other MCP Clients</strong> (VSCode, Windsurf, etc.)</summary>
+<summary><strong>Other MCP Clients</strong> (VSCode + Copilot, Windsurf, Lovable, Replit, etc.)</summary>
 
-Add to your MCP client configuration file:
+For clients that don't have a dedicated Miro plugin or extension, add to your MCP client configuration file:
 
 ```json
 {
@@ -156,6 +160,9 @@ Add to your MCP client configuration file:
   }
 }
 ```
+
+> **Note:** If a Miro plugin or extension becomes available for your client later,
+> switch to it and remove the manual entry to avoid duplicate servers.
 
 See [MCP Setup Guide](docs/getting-started/mcp-setup.md) for client-specific paths.
 
@@ -189,6 +196,18 @@ Test your setup with these example prompts:
 ### Developer Mode
 
 Want to modify plugins, test changes locally, or build your own? See [CONTRIBUTING.md](CONTRIBUTING.md#local-development-setup) for dev setup instructions.
+
+### Avoiding Duplicate Servers
+
+Each installation method (plugin/extension, manual JSON config, local dev server) creates an **independent MCP connection** with its own OAuth session. Running more than one at a time causes duplicate tools, repeated auth prompts, and confused AI responses.
+
+**Rules of thumb:**
+
+1. **If your client has a Miro plugin or extension** (Claude Code, Cursor, Gemini CLI, Kiro) — use only that. Do not also add `https://mcp.miro.com/` to your MCP config manually.
+2. **If your client has no plugin** (VSCode + Copilot, Windsurf, etc.) — manual config is the correct approach. If a plugin becomes available later, switch to it and remove the manual entry.
+3. **If you're running a local dev server** — add it at **project scope** with a distinct name (e.g., `miro-local`) so it doesn't collide with the production server.
+
+See [Troubleshooting: Duplicate Servers](docs/troubleshooting.md#duplicate-mcp-servers) for diagnosis and cleanup steps.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Optional plugins:
 /plugin install miro-review@miro-ai      # Code review workflows
 ```
 
-**Restart Claude Code** after installation. If you previously configured Miro MCP manually, [remove the duplicate](docs/troubleshooting.md#duplicate-mcp-servers) to avoid conflicts — the plugin already manages the MCP connection for you.
+**Restart Claude Code** after installation. If you previously configured Miro MCP manually, [remove the duplicate](https://developers.miro.com/docs/miro-mcp-server-faq-and-troubleshooting#-duplicate-mcp-servers) to avoid conflicts — the plugin already manages the MCP connection for you.
 
 See [Claude Code Plugins](docs/claude-code/overview.md) for full documentation.
 
@@ -140,7 +140,7 @@ cp -r miro-ai/cursor-plugins/miro ~/.cursor/plugins/miro
 
 > **Important:** If you previously added Miro MCP manually (via Settings > MCP Servers),
 > remove that entry — the plugin already manages the MCP connection for you.
-> See [Avoiding Duplicate Servers](#avoiding-duplicate-servers).
+> See [Avoiding Duplicate Servers](#avoiding-duplicate-servers) for details.
 
 See [Cursor Plugins](docs/cursor/overview.md) for full documentation.
 
@@ -199,15 +199,9 @@ Want to modify plugins, test changes locally, or build your own? See [CONTRIBUTI
 
 ### Avoiding Duplicate Servers
 
-Each installation method (plugin/extension, manual JSON config, local dev server) creates an **independent MCP connection** with its own OAuth session. Running more than one at a time causes duplicate tools, repeated auth prompts, and confused AI responses.
+If your client has a Miro plugin or extension, use **only** that — do not also add `https://mcp.miro.com/` manually. Each installation method creates an independent MCP connection with its own OAuth session, and running more than one causes duplicate tools and auth confusion.
 
-**Rules of thumb:**
-
-1. **If your client has a Miro plugin or extension** (Claude Code, Cursor, Gemini CLI, Kiro) — use only that. Do not also add `https://mcp.miro.com/` to your MCP config manually.
-2. **If your client has no plugin** (VSCode + Copilot, Windsurf, etc.) — manual config is the correct approach. If a plugin becomes available later, switch to it and remove the manual entry.
-3. **If you're running a local dev server** — add it at **project scope** with a distinct name (e.g., `miro-local`) so it doesn't collide with the production server.
-
-See [Troubleshooting: Duplicate Servers](docs/troubleshooting.md#duplicate-mcp-servers) for diagnosis and cleanup steps.
+See the [Duplicate MCP Servers](https://developers.miro.com/docs/miro-mcp-server-faq-and-troubleshooting#-duplicate-mcp-servers) guide in Miro's Developer docs for diagnosis and cleanup steps.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ See the [Duplicate MCP Servers](https://developers.miro.com/docs/miro-mcp-server
 ### Platform Guides
 - [Claude Code Plugins](docs/claude-code/overview.md)
 - [Gemini CLI Extension](docs/gemini-cli/overview.md)
+- [Cursor Plugins](docs/cursor/overview.md)
 - [Agent Skills](docs/agent-skills/overview.md)
 - [Kiro Powers](docs/kiro/overview.md)
 

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -11,8 +11,9 @@ This guide covers configuring Miro MCP (Model Context Protocol) for any compatib
 ## Choose Your Installation Method
 
 > **Important:** Use only **one** method per client. Combining a plugin/extension install
-> with manual JSON config creates duplicate MCP servers, each with its own auth session.
-> This results in duplicate tools and confused AI responses.
+> with manual JSON config creates duplicate MCP servers. See the
+> [Duplicate MCP Servers](https://developers.miro.com/docs/miro-mcp-server-faq-and-troubleshooting#-duplicate-mcp-servers)
+> guide for details.
 
 ### Clients with Plugin / Extension Support
 
@@ -27,12 +28,7 @@ These clients have a dedicated Miro integration that manages the MCP connection 
 
 Restart Claude Code and authenticate when prompted.
 
-If you previously configured Miro MCP manually, remove it:
-
-```bash
-claude mcp remove miro --scope user
-claude mcp remove miro --scope local
-```
+If you previously configured Miro MCP manually, [remove the duplicate](https://developers.miro.com/docs/miro-mcp-server-faq-and-troubleshooting#-duplicate-mcp-servers).
 
 For manual configuration (development only), see [CONTRIBUTING.md](../../CONTRIBUTING.md#claude-code-plugins).
 
@@ -42,7 +38,7 @@ For manual configuration (development only), see [CONTRIBUTING.md](../../CONTRIB
 2. Run **Add Plugin** and search for "Miro"
 3. Restart Cursor and complete OAuth when prompted
 
-If you previously added Miro via Settings > Features > MCP Servers, remove that entry to avoid duplicates.
+If you previously added Miro via Settings > Features > MCP Servers, [remove that entry](https://developers.miro.com/docs/miro-mcp-server-faq-and-troubleshooting#-duplicate-mcp-servers) to avoid duplicates.
 
 #### Gemini CLI
 
@@ -75,7 +71,7 @@ For clients that don't have a dedicated Miro plugin or extension, add this to yo
 ```
 
 > If a Miro plugin or extension becomes available for your client later, switch to it
-> and remove the manual entry to avoid duplicate servers.
+> and remove the manual entry to [avoid duplicate servers](https://developers.miro.com/docs/miro-mcp-server-faq-and-troubleshooting#-duplicate-mcp-servers).
 
 #### VSCode + GitHub Copilot
 
@@ -96,22 +92,6 @@ The following clients support Miro MCP with the standard JSON configuration abov
 - OpenAI Codex
 
 Refer to each client's documentation for their specific MCP configuration file location.
-
-## For MCP Server Developers
-
-If you're developing or testing the Miro MCP server locally, add the local server at **project scope** (not user scope) with a **distinct name**:
-
-```json
-{
-  "mcpServers": {
-    "miro-local": {
-      "url": "http://localhost:9111/"
-    }
-  }
-}
-```
-
-This keeps the local dev server isolated to your workspace and avoids collisions with the production plugin or manual config.
 
 ## OAuth Authentication
 

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -8,9 +8,61 @@ This guide covers configuring Miro MCP (Model Context Protocol) for any compatib
 - A Miro account with access to the boards you want to work with
 - Network access to `https://mcp.miro.com/`
 
-## Basic Configuration
+## Choose Your Installation Method
 
-Add this configuration to your MCP client:
+> **Important:** Use only **one** method per client. Combining a plugin/extension install
+> with manual JSON config creates duplicate MCP servers, each with its own auth session.
+> This results in duplicate tools and confused AI responses.
+
+### Clients with Plugin / Extension Support
+
+These clients have a dedicated Miro integration that manages the MCP connection for you. **Do not also add manual MCP config** — the plugin/extension handles it.
+
+#### Claude Code
+
+```bash
+/plugin marketplace add miroapp/miro-ai
+/plugin install miro@miro-ai
+```
+
+Restart Claude Code and authenticate when prompted.
+
+If you previously configured Miro MCP manually, remove it:
+
+```bash
+claude mcp remove miro --scope user
+claude mcp remove miro --scope local
+```
+
+For manual configuration (development only), see [CONTRIBUTING.md](../../CONTRIBUTING.md#claude-code-plugins).
+
+#### Cursor
+
+1. Open Command Palette (`Cmd/Ctrl + Shift + P`)
+2. Run **Add Plugin** and search for "Miro"
+3. Restart Cursor and complete OAuth when prompted
+
+If you previously added Miro via Settings > Features > MCP Servers, remove that entry to avoid duplicates.
+
+#### Gemini CLI
+
+```bash
+gemini extensions install https://github.com/miroapp/miro-ai
+```
+
+Restart Gemini CLI and authenticate when prompted.
+
+For manual configuration (development only), see [CONTRIBUTING.md](../../CONTRIBUTING.md#gemini-cli-extensions).
+
+#### Kiro
+
+1. Open the **Powers** panel in Kiro
+2. Click **Add power from GitHub**
+3. Enter: `miroapp/miro-ai` and select `powers/code-gen`
+
+### Clients with Manual MCP Config Only
+
+For clients that don't have a dedicated Miro plugin or extension, add this to your MCP configuration file:
 
 ```json
 {
@@ -22,36 +74,10 @@ Add this configuration to your MCP client:
 }
 ```
 
-## Client-Specific Setup
+> If a Miro plugin or extension becomes available for your client later, switch to it
+> and remove the manual entry to avoid duplicate servers.
 
-### Claude Code
-
-```bash
-/plugin marketplace add miroapp/miro-ai
-/plugin install miro@miro-ai
-```
-
-Restart Claude Code and authenticate when prompted.
-
-For manual configuration, see [CONTRIBUTING.md](../../CONTRIBUTING.md#claude-code-plugins).
-
-### Cursor
-
-1. Open Settings (`Cmd/Ctrl + ,`)
-2. Navigate to **Features** > **MCP Servers**
-3. Click **Add Server** and add:
-
-```json
-{
-  "miro": {
-    "url": "https://mcp.miro.com/"
-  }
-}
-```
-
-4. Click **Connect** and complete OAuth
-
-### VSCode + GitHub Copilot
+#### VSCode + GitHub Copilot
 
 1. Install the MCP extension for VSCode
 2. Open Command Palette (`Cmd/Ctrl + Shift + P`)
@@ -59,26 +85,33 @@ For manual configuration, see [CONTRIBUTING.md](../../CONTRIBUTING.md#claude-cod
 4. Enter URL: `https://mcp.miro.com/`
 5. Complete OAuth flow
 
-### Gemini CLI
+#### Other Clients
 
-```bash
-gemini extensions install https://github.com/miroapp/miro-ai
-```
-
-For manual configuration, see [CONTRIBUTING.md](../../CONTRIBUTING.md#gemini-cli-extensions).
-
-### Other Clients
-
-The following clients support Miro MCP with standard configuration:
+The following clients support Miro MCP with the standard JSON configuration above:
+- Windsurf
 - Lovable
 - Replit
-- Windsurf
-- Kiro
 - Glean
 - Devin
 - OpenAI Codex
 
-Refer to each client's documentation for their specific MCP configuration location.
+Refer to each client's documentation for their specific MCP configuration file location.
+
+## For MCP Server Developers
+
+If you're developing or testing the Miro MCP server locally, add the local server at **project scope** (not user scope) with a **distinct name**:
+
+```json
+{
+  "mcpServers": {
+    "miro-local": {
+      "url": "http://localhost:9111/"
+    }
+  }
+}
+```
+
+This keeps the local dev server isolated to your workspace and avoids collisions with the production plugin or manual config.
 
 ## OAuth Authentication
 

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -83,11 +83,12 @@ For clients that don't have a dedicated Miro plugin or extension, add this to yo
 
 #### VSCode + GitHub Copilot
 
-1. Install the MCP extension for VSCode
-2. Open Command Palette (`Cmd/Ctrl + Shift + P`)
-3. Run **MCP: Add Server**
-4. Enter URL: `https://mcp.miro.com/`
-5. Complete OAuth flow
+Install from the [GitHub MCP Registry](https://github.com/mcp/miroapp/mcp-server):
+
+1. On the registry page, click **Install MCP Server**
+2. Select **Install in VS Code** (or VS Code Insiders)
+3. VS Code will open and prompt you to confirm the server installation
+4. Complete the OAuth flow when prompted
 
 #### Other Clients
 

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -32,14 +32,6 @@ If you previously configured Miro MCP manually, [remove the duplicate](https://d
 
 For manual configuration (development only), see [CONTRIBUTING.md](../../CONTRIBUTING.md#claude-code-plugins).
 
-#### Cursor
-
-1. Open Command Palette (`Cmd/Ctrl + Shift + P`)
-2. Run **Add Plugin** and search for "Miro"
-3. Restart Cursor and complete OAuth when prompted
-
-If you previously added Miro via Settings > Features > MCP Servers, [remove that entry](https://developers.miro.com/docs/miro-mcp-server-faq-and-troubleshooting#-duplicate-mcp-servers) to avoid duplicates.
-
 #### Gemini CLI
 
 ```bash
@@ -72,6 +64,22 @@ For clients that don't have a dedicated Miro plugin or extension, add this to yo
 
 > If a Miro plugin or extension becomes available for your client later, switch to it
 > and remove the manual entry to [avoid duplicate servers](https://developers.miro.com/docs/miro-mcp-server-faq-and-troubleshooting#-duplicate-mcp-servers).
+
+#### Cursor
+
+1. Open Settings (`Cmd/Ctrl + ,`)
+2. Navigate to **Features** > **MCP Servers**
+3. Click **Add Server** and add:
+
+```json
+{
+  "miro": {
+    "url": "https://mcp.miro.com/"
+  }
+}
+```
+
+4. Click **Connect** and complete OAuth
 
 #### VSCode + GitHub Copilot
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -40,68 +40,9 @@ Common issues and solutions for Miro AI integrations.
 
 ## Duplicate MCP Servers
 
-### Multiple Miro Servers Active
+If you're seeing duplicate Miro tools, repeated auth prompts, or your AI is confused about which Miro server to use, you likely have multiple Miro MCP server instances active.
 
-**Symptoms:**
-- Duplicate Miro tools in the tool list
-- Being prompted to authenticate with Miro multiple times
-- AI unsure which set of Miro tools to use
-- Multiple Miro entries in your MCP server list
-
-**Cause:** There are three ways Miro MCP can be configured, and each creates an independent server instance with its own auth session:
-
-| Source | Typical scope | Who it's for |
-|--------|--------------|--------------|
-| **Plugin / extension** (from miro-ai repo) | User | Everyone — recommended for clients that support it |
-| **Manual JSON config** (`"url": "https://mcp.miro.com/"`) | User or project | Clients without plugin/extension support |
-| **Local dev server** (`http://localhost:...`) | Project | MCP server developers only |
-
-If more than one is active in the same client, you get duplicate tools and auth conflicts — even though they point to the same server.
-
-**How to check:** Look at your client's MCP server list. If you see more than one Miro entry (excluding a local dev server you intentionally configured), you have duplicates.
-
-**Fix — use only one method per client:**
-
-#### If your client has a Miro plugin or extension
-
-For **Claude Code**, **Cursor**, **Gemini CLI**, and **Kiro**: the plugin/extension already manages the MCP connection. Remove any manual config:
-
-**Claude Code:**
-```bash
-claude mcp remove miro --scope user
-claude mcp remove miro --scope local
-```
-If you named the server differently, check `claude mcp list` for the actual name and substitute it.
-
-**Cursor:**
-1. Open Settings (`Cmd/Ctrl + ,`)
-2. Navigate to **Features** > **MCP Servers**
-3. Delete any manually-added "miro" entry pointing to `https://mcp.miro.com/`
-
-**Gemini CLI:**
-Remove any manually-added `miro` server entry from your MCP configuration in `settings.json`.
-
-Restart your client after removal.
-
-#### If your client has no plugin
-
-For **VSCode + Copilot**, **Windsurf**, and other clients without a dedicated Miro plugin: manual JSON config is the correct approach. Just ensure you have only **one** `miro` entry.
-
-If a Miro plugin becomes available for your client later, switch to it and remove the manual entry.
-
-#### If you're also running a local dev server
-
-Use a **distinct name** (e.g., `miro-local`) at **project scope** so it doesn't collide with the production server:
-
-```json
-{
-  "mcpServers": {
-    "miro-local": {
-      "url": "http://localhost:9111/"
-    }
-  }
-}
-```
+See the [Duplicate MCP Servers](https://developers.miro.com/docs/miro-mcp-server-faq-and-troubleshooting#-duplicate-mcp-servers) guide in Miro's Developer docs for causes and client-specific cleanup steps.
 
 ## Authentication Issues
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -40,26 +40,68 @@ Common issues and solutions for Miro AI integrations.
 
 ## Duplicate MCP Servers
 
-### Plugin and Manual Config Both Active
+### Multiple Miro Servers Active
 
 **Symptoms:**
-- Duplicate Miro tools in the tool list (e.g., both `mcp__miro__*` and `mcp__plugin_miro_miro__*`)
+- Duplicate Miro tools in the tool list
 - Being prompted to authenticate with Miro multiple times
-- Claude unsure which set of Miro tools to use
-- `/mcp` shows multiple Miro servers
+- AI unsure which set of Miro tools to use
+- Multiple Miro entries in your MCP server list
 
-**Cause:** Claude Code namespaces plugin MCP tools (`mcp__plugin_miro_miro__*`) separately from user-configured ones (`mcp__miro__*`). If you installed the plugin **and** previously added Miro MCP manually, both load independently — even though they point to the same server. Each maintains its own auth session.
+**Cause:** There are three ways Miro MCP can be configured, and each creates an independent server instance with its own auth session:
 
-**How to check:** Run `/mcp` or `claude mcp list` to see all active servers. If you see more than one Miro entry, you have duplicates.
+| Source | Typical scope | Who it's for |
+|--------|--------------|--------------|
+| **Plugin / extension** (from miro-ai repo) | User | Everyone — recommended for clients that support it |
+| **Manual JSON config** (`"url": "https://mcp.miro.com/"`) | User or project | Clients without plugin/extension support |
+| **Local dev server** (`http://localhost:...`) | Project | MCP server developers only |
 
-**Fix:** Remove the manual configuration since the plugin already provides it:
+If more than one is active in the same client, you get duplicate tools and auth conflicts — even though they point to the same server.
 
+**How to check:** Look at your client's MCP server list. If you see more than one Miro entry (excluding a local dev server you intentionally configured), you have duplicates.
+
+**Fix — use only one method per client:**
+
+#### If your client has a Miro plugin or extension
+
+For **Claude Code**, **Cursor**, **Gemini CLI**, and **Kiro**: the plugin/extension already manages the MCP connection. Remove any manual config:
+
+**Claude Code:**
 ```bash
 claude mcp remove miro --scope user
 claude mcp remove miro --scope local
 ```
+If you named the server differently, check `claude mcp list` for the actual name and substitute it.
 
-If you named the server differently, check `claude mcp list` for the actual name and substitute it. Restart Claude Code after removal.
+**Cursor:**
+1. Open Settings (`Cmd/Ctrl + ,`)
+2. Navigate to **Features** > **MCP Servers**
+3. Delete any manually-added "miro" entry pointing to `https://mcp.miro.com/`
+
+**Gemini CLI:**
+Remove any manually-added `miro` server entry from your MCP configuration in `settings.json`.
+
+Restart your client after removal.
+
+#### If your client has no plugin
+
+For **VSCode + Copilot**, **Windsurf**, and other clients without a dedicated Miro plugin: manual JSON config is the correct approach. Just ensure you have only **one** `miro` entry.
+
+If a Miro plugin becomes available for your client later, switch to it and remove the manual entry.
+
+#### If you're also running a local dev server
+
+Use a **distinct name** (e.g., `miro-local`) at **project scope** so it doesn't collide with the production server:
+
+```json
+{
+  "mcpServers": {
+    "miro-local": {
+      "url": "http://localhost:9111/"
+    }
+  }
+}
+```
 
 ## Authentication Issues
 


### PR DESCRIPTION
## Summary

Addresses [CADE-1555](https://miro.atlassian.net/browse/CADE-1555) — users can end up with multiple Miro MCP server instances (plugin + manual config + local dev server) causing duplicate tools, repeated auth prompts, and confused AI responses.

This PR restructures setup and troubleshooting docs to be **client-agnostic** with a single principle: **one install method per client**.

### Changes

- **README.md**
  - Added duplicate server warning to Cursor plugin section
  - Clarified "Other MCP Clients" is for clients *without* plugin support
  - Added new "Avoiding Duplicate Servers" section with rules of thumb

- **docs/getting-started/mcp-setup.md**
  - Restructured around two categories: "Clients with Plugin/Extension Support" vs "Clients with Manual MCP Config Only"
  - Removed manual JSON config as the primary/universal method — now only shown for clients without plugins
  - Added "For MCP Server Developers" section (use distinct name `miro-local` at project scope)
  - Added per-client instructions for removing duplicate manual config

- **docs/troubleshooting.md**
  - Rewrote "Duplicate MCP Servers" section from Claude-Code-specific to client-agnostic
  - Added table explaining the three installation sources and their intended audience
  - Added per-client cleanup instructions (Claude Code, Cursor, Gemini CLI)
  - Added local dev server guidance (distinct name, project scope)

### Key principle reinforced everywhere

> If your client has a Miro plugin or extension, use only that. Do not also add `https://mcp.miro.com/` manually. If you need a local dev server, use a different name (`miro-local`) at project scope.

### Also needed (separate from this PR)

Suggested content for the [developers.miro.com FAQ](https://developers.miro.com/docs/miro-mcp-server-faq-and-troubleshooting) page — see PR description comments.

## Test plan

- [ ] Verify all internal doc links resolve correctly
- [ ] Verify README renders properly on GitHub (especially `<details>` blocks and blockquotes)
- [ ] Review with team for accuracy of per-client cleanup instructions


Made with [Cursor](https://cursor.com)