### PR TITLE
fix: restore Claude marketplace plugin entries

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -38,6 +38,151 @@
         "mcp",
         "workspace"
       ]
+    },
+    {
+      "name": "miro-tasks",
+      "description": "Track your coding progress on a Miro board. Automatically syncs todos and task status to visual cards.",
+      "source": "./claude-plugins/miro-tasks",
+      "category": "development",
+      "version": "1.0.2",
+      "author": {
+        "name": "Miro",
+        "email": "support@miro.com"
+      },
+      "homepage": "https://miro.com",
+      "repository": "https://github.com/miroapp/miro-ai",
+      "license": "MIT",
+      "keywords": [
+        "miro", "whiteboard", "boards", "diagrams", "flowchart", "mindmap", "uml",
+        "mermaid", "plantuml", "documents", "tables", "stickies", "wireframes",
+        "prototypes", "visualization", "collaboration", "design-to-code", "mcp",
+        "prd", "specs", "documentation", "planning", "frames", "cards", "shapes",
+        "connectors", "images", "extraction", "design", "requirements", "tasks",
+        "tracking", "todos", "project-management", "kanban", "sync", "progress"
+      ],
+      "tags": [
+        "development",
+        "productivity",
+        "project-management",
+        "tracking"
+      ]
+    },
+    {
+      "name": "miro-solutions",
+      "description": "Create customer-specific Miro plugins during sales calls. Rapid plugin generation for Solution Architects.",
+      "source": "./claude-plugins/miro-solutions",
+      "category": "development",
+      "version": "1.0.2",
+      "author": {
+        "name": "Miro",
+        "email": "support@miro.com"
+      },
+      "homepage": "https://miro.com",
+      "repository": "https://github.com/miroapp/miro-ai",
+      "license": "MIT",
+      "keywords": [
+        "miro", "whiteboard", "boards", "diagrams", "flowchart", "mindmap", "uml",
+        "mermaid", "plantuml", "documents", "tables", "stickies", "wireframes",
+        "prototypes", "visualization", "collaboration", "design-to-code", "mcp",
+        "prd", "specs", "documentation", "planning", "frames", "cards", "shapes",
+        "connectors", "images", "extraction", "design", "requirements", "tasks",
+        "tracking", "todos", "project-management", "kanban", "sync",
+        "solutions", "sales", "plugin-generator", "gtm", "demo", "customer", "platform"
+      ],
+      "tags": [
+        "development",
+        "sales",
+        "automation",
+        "plugin-creation"
+      ]
+    },
+    {
+      "name": "miro-research",
+      "description": "Research any topic and visualize findings on Miro boards. Uses available tools (Glean, local repos) and creates docs, tables, and diagrams.",
+      "source": "./claude-plugins/miro-research",
+      "category": "productivity",
+      "version": "1.0.2",
+      "author": {
+        "name": "Miro",
+        "email": "support@miro.com"
+      },
+      "homepage": "https://miro.com",
+      "repository": "https://github.com/miroapp/miro-ai",
+      "license": "MIT",
+      "keywords": [
+        "miro", "whiteboard", "boards", "diagrams", "flowchart", "mindmap", "uml",
+        "mermaid", "plantuml", "documents", "tables", "stickies", "wireframes",
+        "prototypes", "visualization", "collaboration", "design-to-code", "mcp",
+        "prd", "specs", "documentation", "planning", "frames", "cards", "shapes",
+        "connectors", "images", "extraction", "design", "requirements", "tasks",
+        "tracking", "todos", "project-management", "kanban", "sync",
+        "research", "glean", "knowledge-synthesis"
+      ],
+      "tags": [
+        "productivity",
+        "research",
+        "visualization",
+        "documentation"
+      ]
+    },
+    {
+      "name": "miro-review",
+      "description": "Visual code reviews on Miro boards. Generates comprehensive review artifacts from GitHub PRs or local changes with security and architecture analysis.",
+      "source": "./claude-plugins/miro-review",
+      "category": "development",
+      "version": "1.0.3",
+      "author": {
+        "name": "Miro",
+        "email": "support@miro.com"
+      },
+      "homepage": "https://miro.com",
+      "repository": "https://github.com/miroapp/miro-ai",
+      "license": "MIT",
+      "keywords": [
+        "miro", "whiteboard", "boards", "diagrams", "flowchart", "mindmap", "uml",
+        "mermaid", "plantuml", "documents", "tables", "stickies", "wireframes",
+        "prototypes", "visualization", "collaboration", "design-to-code", "mcp",
+        "prd", "specs", "documentation", "planning", "frames", "cards", "shapes",
+        "connectors", "images", "extraction", "design", "requirements", "tasks",
+        "tracking", "todos", "project-management", "kanban", "sync",
+        "code-review", "pr-review", "pull-request", "github", "security-review",
+        "architecture", "diff"
+      ],
+      "tags": [
+        "development",
+        "code-review",
+        "security",
+        "visualization",
+        "collaboration"
+      ]
+    },
+    {
+      "name": "miro-spec",
+      "description": "Extract and save Miro Specs to local files for AI-assisted planning and implementation. Downloads documents, diagrams, prototypes, and images.",
+      "source": "./claude-plugins/miro-spec",
+      "category": "productivity",
+      "version": "1.0.1",
+      "author": {
+        "name": "Miro",
+        "email": "support@miro.com"
+      },
+      "homepage": "https://miro.com",
+      "repository": "https://github.com/miroapp/miro-ai",
+      "license": "MIT",
+      "keywords": [
+        "miro", "whiteboard", "boards", "diagrams", "flowchart", "mindmap", "uml",
+        "mermaid", "plantuml", "documents", "tables", "stickies", "wireframes",
+        "prototypes", "visualization", "collaboration", "design-to-code", "mcp",
+        "prd", "specs", "documentation", "planning", "frames", "cards", "shapes",
+        "connectors", "images", "extraction", "design", "requirements", "tasks",
+        "tracking", "todos", "project-management", "kanban", "sync"
+      ],
+      "tags": [
+        "productivity",
+        "documentation",
+        "planning",
+        "extraction"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- restore the removed Claude marketplace plugin entries in .claude-plugin/marketplace.json
- align restored marketplace versions with the current plugin manifests on main

## Testing
- bun run validate *(fails locally because dependencies are not installed: missing fast-glob)*