### PR TITLE
fix(skills): place artifacts inside parent frame from URL

### DIFF
--- a/claude-plugins/miro/skills/miro-code-review/SKILL.md
+++ b/claude-plugins/miro/skills/miro-code-review/SKILL.md
@@ -1,38 +1,69 @@
 ---
 name: miro-code-review
-description: Use when the user wants to create a visual code review on a Miro board from a GitHub PR (current or external repo), local uncommitted changes, or a branch comparison — produces a file-changes table, summary/architecture/security docs, and architecture diagrams.
+description: Use when the user wants to create a visual code review on a Miro board from a pull/merge request (GitHub, GitLab, or any forge), local uncommitted changes, or a branch comparison — produces a file-changes table, summary/architecture/security docs, and architecture diagrams, then links them back from the PR/MR.
 ---
 
 # Visual Code Review
 
-Generate a comprehensive visual code review on a Miro board from GitHub PRs, local changes, or branch comparisons. Includes architecture analysis, security review, and optionally enriches with enterprise documentation.
+Generate a comprehensive visual code review on a Miro board from a pull/merge request, local changes, or a branch comparison. Includes architecture analysis, security review, and optionally enriches with enterprise documentation. After the artifacts are created, link them back from the PR/MR description so reviewers can find them without leaving their forge.
 
-The user provides a Miro board URL plus one source: a PR number, `owner/repo#number`, a full PR URL, the keyword "local changes", or a branch name to compare against main.
+The user provides a Miro board URL plus one source: a PR/MR number, `owner/repo#number` (or `group/project!number`), a full PR/MR URL, the keyword "local changes", or a branch name to compare against the default branch. The skill is platform-agnostic: it detects the forge from the URL or the configured git remote and uses whichever CLI is available locally.
 
 ## Workflow
 
 ### 1. Identify the source from the user's request
 
-Determine the source type:
-- A bare number → GitHub PR in the current repo
-- `owner/repo#number` → External GitHub PR
-- A GitHub URL → Extract owner, repo, and PR number from the URL
-- "local changes" / uncommitted work → Local changes
-- A branch name → Branch comparison against main
+Determine the source type and infer the platform from the URL or configured git remote:
+
+- A bare number → PR/MR in the current repo (infer the platform from the configured git remote: `git remote get-url origin`)
+- `owner/repo#number` (or `group/project!number` for GitLab-style) → PR/MR in an external repo on the same platform as the current remote, unless a host is given
+- A full URL → extract host, owner/group, repo/project, and PR/MR number from the URL; the host determines the platform
+- "local changes" / uncommitted work → local diff only, no PR
+- A branch name → local diff against the default branch (`main` or whatever the remote shows as default)
+
+#### Tool selection
+
+Pick the CLI based on what's installed and what the source points at. Do not assume `gh`. Run `command -v <cli>` to check availability before invoking:
+
+- GitHub URLs / `github.com` remote → `gh` CLI if available
+- GitLab URLs / `gitlab.com` or self-hosted GitLab → `glab` CLI if available
+- If no first-party CLI is available for the detected platform, fall back to authenticated REST via `curl` using whatever credentials the user already has configured (e.g. `~/.netrc`, env var tokens like `$GITHUB_TOKEN`, `$GITLAB_TOKEN`)
+- For local / branch-comparison sources, plain `git` is sufficient — no platform CLI needed
+
+State the detected platform and tool in chat output before proceeding.
 
 ### 2. Extract Changes
 
-**For GitHub PR (current repo):**
+Fetch two things, regardless of platform:
+
+1. **Metadata**: title, description/body, author, list of changed files with additions/deletions per file
+2. **Unified diff** of the change
+
+Use whichever CLI matches the platform detected in §1; the JSON/text shape will differ between forges — normalize fields downstream.
+
+**GitHub example (`gh`):**
 ```bash
+# Current repo
 gh pr view $PR_NUMBER --json title,body,author,files,additions,deletions
 gh pr diff $PR_NUMBER
-```
 
-**For GitHub PR (external repo):**
-```bash
+# External repo
 gh pr view $PR_NUMBER --repo $OWNER/$REPO --json title,body,author,files,additions,deletions
 gh pr diff $PR_NUMBER --repo $OWNER/$REPO
 ```
+
+**GitLab example (`glab`):**
+```bash
+# Current project
+glab mr view $MR_NUMBER -F json
+glab mr diff $MR_NUMBER
+
+# External project
+glab mr view $MR_NUMBER -R $GROUP/$PROJECT -F json
+glab mr diff $MR_NUMBER -R $GROUP/$PROJECT
+```
+
+**REST fallback (any platform):** issue an authenticated `curl` to the platform's REST endpoint for the PR/MR and its diff. Use the user's configured token (`$GITHUB_TOKEN`, `$GITLAB_TOKEN`, etc.) and pass `Accept: application/vnd.github.v3.diff` (or platform equivalent) for the diff.
 
 **For Local Changes:**
 ```bash
@@ -42,8 +73,9 @@ git diff HEAD
 
 **For Branch Comparison:**
 ```bash
-git log main..HEAD --oneline
-git diff main...HEAD
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+git log $DEFAULT_BRANCH..HEAD --oneline
+git diff $DEFAULT_BRANCH...HEAD
 ```
 
 ### 3. Analyze Changes
@@ -275,14 +307,75 @@ Adjust starting x based on actual number of documents created.
 - Dependencies between changed files
 - Trust boundaries (for security-relevant changes)
 
+### 6. Post link back to PR/MR
+
+Once the artifacts are created, surface the link from the PR/MR itself so reviewers see it without leaving their forge.
+
+**Skip this step entirely** when:
+- The source is "local changes"
+- The source is a branch with no associated open PR/MR
+
+In those cases the link is reported only in chat output (see §Output below).
+
+#### Block format
+
+Append a delimited block to the existing PR/MR description. Reuse the same delimiters on every run so the block can be replaced cleanly:
+
+```
+<!-- miro-pr-docs:start -->
+## PR documentation
+
+PR details on Miro: <link>
+
+- <X> documents, <Y> diagrams, <Z> table rows
+- High-risk files: <count>
+- Security findings: <count>
+<!-- miro-pr-docs:end -->
+```
+
+**Link rules:**
+- If the original Miro URL contained `moveToWidget=<frameId>`, reuse that exact URL — clicking opens straight to the frame
+- Otherwise use the plain board URL
+
+**Idempotency:**
+- If the description already contains the `<!-- miro-pr-docs:start -->` … `<!-- miro-pr-docs:end -->` markers, replace the contents in place
+- Otherwise append the block at the end of the existing description, preserving everything else verbatim
+- Never overwrite the user-authored portion of the description
+
+#### Update the description
+
+Use the same CLI selection from §1. Read the current body, splice the new block, write it back.
+
+**GitHub example (`gh`):**
+```bash
+# Read current body
+BODY=$(gh pr view $PR_NUMBER --json body -q .body)
+# (splice: replace existing block or append) → produce $NEW_BODY
+gh pr edit $PR_NUMBER --body "$NEW_BODY"
+```
+
+**GitLab example (`glab`):**
+```bash
+BODY=$(glab mr view $MR_NUMBER -F json | jq -r .description)
+# (splice) → $NEW_BODY
+glab mr update $MR_NUMBER --description "$NEW_BODY"
+```
+
+**REST fallback:** read and PATCH the PR/MR body via the platform's REST API with the user's token.
+
+#### Permission failure fallback
+
+If editing the description fails because the user lacks permission (for example, when reviewing someone else's PR), post the same block as a single PR/MR comment instead. Mention this fallback in the chat output so the user knows the description was not changed.
+
 ## Output
 
 After completion, provide:
-1. Link to the Miro board
-2. Summary of elements created (X docs, Y diagrams, Z table rows)
-3. High-risk files requiring careful review
-4. Security findings (if any critical/high)
-5. Architecture concerns (if any breaking changes)
+1. Link to the Miro board (or frame, if `moveToWidget` was provided)
+2. Confirmation that the PR/MR description was updated, or that we left a comment as a fallback, or that the post step was skipped because the source was local / branchless
+3. Summary of elements created (X docs, Y diagrams, Z table rows)
+4. High-risk files requiring careful review
+5. Security findings (if any critical/high)
+6. Architecture concerns (if any breaking changes)
 
 ## Background
 

--- a/claude-plugins/miro/skills/miro-diagram/SKILL.md
+++ b/claude-plugins/miro/skills/miro-diagram/SKILL.md
@@ -28,7 +28,7 @@ Automatically detect or let the user specify:
 2. If description is missing or unclear, ask what they want to diagram
 3. Determine the appropriate diagram type from the description (or ask if ambiguous)
 4. *(Optional, for precise control)* Call `diagram_get_dsl` first to fetch the DSL spec — useful when the user wants a structurally complex diagram and you'd rather author the DSL directly than rely on natural language.
-5. Call `diagram_create` with the board URL, the diagram description, and optionally the diagram type if specified. Set `parent_id` to a frame ID if the diagram should sit inside a frame.
+5. Call `diagram_create` with the board URL, the diagram description, and optionally the diagram type if specified. To place the diagram inside a frame, pass the board URL with `?moveToWidget=<frame_id>` — the tool detects the frame target automatically (no `parent_id` argument exists). When that URL is used, `x` and `y` become coordinates relative to the frame's top-left corner.
 6. Report success with a link to the board
 
 ## Examples
@@ -68,13 +68,16 @@ flowchart TD
     E --> F[Create Account]
 ```
 
-## Positioning on the Board
+## Positioning
 
-Board coordinates use a Cartesian system with center at `(0, 0)`. Positive X goes right, positive Y goes down.
+Two coordinate systems depending on whether the URL targets a frame:
 
-**Spacing recommendations** when placing multiple items:
+- **Board-level** (URL has no `moveToWidget`): Cartesian with the board center at `(0, 0)`. Positive x goes right, positive y goes down.
+- **Frame target** (URL has `?moveToWidget=<frame_id>`): coordinates are relative to the frame's top-left corner; `(0, 0)` is the frame's top-left. The diagram must fit within the frame's width and height. Targets that point at a non-frame item are silently ignored, so the diagram lands on the board.
+
+**Spacing recommendations** when placing multiple items at the board level:
 - Diagrams: 2000–3000 units apart
 - Documents: 500–1000 units apart
 - Tables: 1500–2000 units apart
 
-To place a diagram inside a frame, set `parent_id` to the frame's ID.
+When placing multiple items inside a single frame, fetch the frame's geometry first (e.g. via `context_get` with the frame URL) and lay them out in a grid that fits within the frame's width and height.

--- a/claude-plugins/miro/skills/miro-doc/SKILL.md
+++ b/claude-plugins/miro/skills/miro-doc/SKILL.md
@@ -30,8 +30,13 @@ The document supports:
    - If it's actual document content, use it directly
    - If it's a topic/request, generate appropriate document content
 3. If content is missing, ask what document they want to create
-4. Call `doc_create` with the board URL and the markdown content. Set `parent_id` to a frame ID if the document should sit inside a frame.
+4. Call `doc_create` with the board URL and the markdown content. To place the document inside a frame, pass the board URL with `?moveToWidget=<frame_id>` — the tool will detect the frame target automatically (no `parent_id` argument exists). When that URL is used, `x` and `y` become coordinates relative to the frame's top-left corner; pick values that fit inside the frame's width and height (default doc width is 800px).
 5. Report success with a link to the board
+
+## Coordinates
+
+- Board-level (URL has no `moveToWidget`): `x=0, y=0` is the board center.
+- Frame target (URL has `?moveToWidget=<frame_id>`): `x=0, y=0` is the frame's top-left corner. The doc's top-left is placed at the given `x, y`, and the doc must fit inside the frame's width and height. Targets that point at a non-frame item (sticky note, shape, diagram) are silently ignored, so the doc lands on the board.
 
 ## Examples
 

--- a/claude-plugins/miro/skills/miro-table/SKILL.md
+++ b/claude-plugins/miro/skills/miro-table/SKILL.md
@@ -25,8 +25,13 @@ Identify from the user's request:
 3. Based on the table purpose, suggest appropriate columns:
    - Propose a default column structure
    - Let user customize or accept defaults
-4. Call `table_create` with the board URL, table name, and column definitions. Set `parent_id` to a frame ID if the table should sit inside a frame.
+4. Call `table_create` with the board URL, table name, and column definitions. To place the table inside a frame, pass the board URL with `?moveToWidget=<frame_id>` — the tool detects the frame target automatically (no `parent_id` argument exists). When that URL is used, `x` and `y` become coordinates relative to the frame's top-left corner; the table must fit within the frame's width and height.
 5. Report success and offer to add initial rows
+
+## Coordinates
+
+- **Board-level** (URL has no `moveToWidget`): board center is `(0, 0)`.
+- **Frame target** (URL has `?moveToWidget=<frame_id>`): `(0, 0)` is the frame's top-left corner. Targets that point at a non-frame item are silently ignored, so the table lands on the board.
 
 ## Common Table Templates
 

--- a/codex-plugins/miro/skills/miro-code-review/SKILL.md
+++ b/codex-plugins/miro/skills/miro-code-review/SKILL.md
@@ -1,38 +1,69 @@
 ---
 name: miro-code-review
-description: Use when the user wants to create a visual code review on a Miro board from a GitHub PR (current or external repo), local uncommitted changes, or a branch comparison — produces a file-changes table, summary/architecture/security docs, and architecture diagrams.
+description: Use when the user wants to create a visual code review on a Miro board from a pull/merge request (GitHub, GitLab, or any forge), local uncommitted changes, or a branch comparison — produces a file-changes table, summary/architecture/security docs, and architecture diagrams, then links them back from the PR/MR.
 ---
 
 # Visual Code Review
 
-Generate a comprehensive visual code review on a Miro board from GitHub PRs, local changes, or branch comparisons. Includes architecture analysis, security review, and optionally enriches with enterprise documentation.
+Generate a comprehensive visual code review on a Miro board from a pull/merge request, local changes, or a branch comparison. Includes architecture analysis, security review, and optionally enriches with enterprise documentation. After the artifacts are created, link them back from the PR/MR description so reviewers can find them without leaving their forge.
 
-The user provides a Miro board URL plus one source: a PR number, `owner/repo#number`, a full PR URL, the keyword "local changes", or a branch name to compare against main.
+The user provides a Miro board URL plus one source: a PR/MR number, `owner/repo#number` (or `group/project!number`), a full PR/MR URL, the keyword "local changes", or a branch name to compare against the default branch. The skill is platform-agnostic: it detects the forge from the URL or the configured git remote and uses whichever CLI is available locally.
 
 ## Workflow
 
 ### 1. Identify the source from the user's request
 
-Determine the source type:
-- A bare number → GitHub PR in the current repo
-- `owner/repo#number` → External GitHub PR
-- A GitHub URL → Extract owner, repo, and PR number from the URL
-- "local changes" / uncommitted work → Local changes
-- A branch name → Branch comparison against main
+Determine the source type and infer the platform from the URL or configured git remote:
+
+- A bare number → PR/MR in the current repo (infer the platform from the configured git remote: `git remote get-url origin`)
+- `owner/repo#number` (or `group/project!number` for GitLab-style) → PR/MR in an external repo on the same platform as the current remote, unless a host is given
+- A full URL → extract host, owner/group, repo/project, and PR/MR number from the URL; the host determines the platform
+- "local changes" / uncommitted work → local diff only, no PR
+- A branch name → local diff against the default branch (`main` or whatever the remote shows as default)
+
+#### Tool selection
+
+Pick the CLI based on what's installed and what the source points at. Do not assume `gh`. Run `command -v <cli>` to check availability before invoking:
+
+- GitHub URLs / `github.com` remote → `gh` CLI if available
+- GitLab URLs / `gitlab.com` or self-hosted GitLab → `glab` CLI if available
+- If no first-party CLI is available for the detected platform, fall back to authenticated REST via `curl` using whatever credentials the user already has configured (e.g. `~/.netrc`, env var tokens like `$GITHUB_TOKEN`, `$GITLAB_TOKEN`)
+- For local / branch-comparison sources, plain `git` is sufficient — no platform CLI needed
+
+State the detected platform and tool in chat output before proceeding.
 
 ### 2. Extract Changes
 
-**For GitHub PR (current repo):**
+Fetch two things, regardless of platform:
+
+1. **Metadata**: title, description/body, author, list of changed files with additions/deletions per file
+2. **Unified diff** of the change
+
+Use whichever CLI matches the platform detected in §1; the JSON/text shape will differ between forges — normalize fields downstream.
+
+**GitHub example (`gh`):**
 ```bash
+# Current repo
 gh pr view $PR_NUMBER --json title,body,author,files,additions,deletions
 gh pr diff $PR_NUMBER
-```
 
-**For GitHub PR (external repo):**
-```bash
+# External repo
 gh pr view $PR_NUMBER --repo $OWNER/$REPO --json title,body,author,files,additions,deletions
 gh pr diff $PR_NUMBER --repo $OWNER/$REPO
 ```
+
+**GitLab example (`glab`):**
+```bash
+# Current project
+glab mr view $MR_NUMBER -F json
+glab mr diff $MR_NUMBER
+
+# External project
+glab mr view $MR_NUMBER -R $GROUP/$PROJECT -F json
+glab mr diff $MR_NUMBER -R $GROUP/$PROJECT
+```
+
+**REST fallback (any platform):** issue an authenticated `curl` to the platform's REST endpoint for the PR/MR and its diff. Use the user's configured token (`$GITHUB_TOKEN`, `$GITLAB_TOKEN`, etc.) and pass `Accept: application/vnd.github.v3.diff` (or platform equivalent) for the diff.
 
 **For Local Changes:**
 ```bash
@@ -42,8 +73,9 @@ git diff HEAD
 
 **For Branch Comparison:**
 ```bash
-git log main..HEAD --oneline
-git diff main...HEAD
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+git log $DEFAULT_BRANCH..HEAD --oneline
+git diff $DEFAULT_BRANCH...HEAD
 ```
 
 ### 3. Analyze Changes
@@ -275,14 +307,75 @@ Adjust starting x based on actual number of documents created.
 - Dependencies between changed files
 - Trust boundaries (for security-relevant changes)
 
+### 6. Post link back to PR/MR
+
+Once the artifacts are created, surface the link from the PR/MR itself so reviewers see it without leaving their forge.
+
+**Skip this step entirely** when:
+- The source is "local changes"
+- The source is a branch with no associated open PR/MR
+
+In those cases the link is reported only in chat output (see §Output below).
+
+#### Block format
+
+Append a delimited block to the existing PR/MR description. Reuse the same delimiters on every run so the block can be replaced cleanly:
+
+```
+<!-- miro-pr-docs:start -->
+## PR documentation
+
+PR details on Miro: <link>
+
+- <X> documents, <Y> diagrams, <Z> table rows
+- High-risk files: <count>
+- Security findings: <count>
+<!-- miro-pr-docs:end -->
+```
+
+**Link rules:**
+- If the original Miro URL contained `moveToWidget=<frameId>`, reuse that exact URL — clicking opens straight to the frame
+- Otherwise use the plain board URL
+
+**Idempotency:**
+- If the description already contains the `<!-- miro-pr-docs:start -->` … `<!-- miro-pr-docs:end -->` markers, replace the contents in place
+- Otherwise append the block at the end of the existing description, preserving everything else verbatim
+- Never overwrite the user-authored portion of the description
+
+#### Update the description
+
+Use the same CLI selection from §1. Read the current body, splice the new block, write it back.
+
+**GitHub example (`gh`):**
+```bash
+# Read current body
+BODY=$(gh pr view $PR_NUMBER --json body -q .body)
+# (splice: replace existing block or append) → produce $NEW_BODY
+gh pr edit $PR_NUMBER --body "$NEW_BODY"
+```
+
+**GitLab example (`glab`):**
+```bash
+BODY=$(glab mr view $MR_NUMBER -F json | jq -r .description)
+# (splice) → $NEW_BODY
+glab mr update $MR_NUMBER --description "$NEW_BODY"
+```
+
+**REST fallback:** read and PATCH the PR/MR body via the platform's REST API with the user's token.
+
+#### Permission failure fallback
+
+If editing the description fails because the user lacks permission (for example, when reviewing someone else's PR), post the same block as a single PR/MR comment instead. Mention this fallback in the chat output so the user knows the description was not changed.
+
 ## Output
 
 After completion, provide:
-1. Link to the Miro board
-2. Summary of elements created (X docs, Y diagrams, Z table rows)
-3. High-risk files requiring careful review
-4. Security findings (if any critical/high)
-5. Architecture concerns (if any breaking changes)
+1. Link to the Miro board (or frame, if `moveToWidget` was provided)
+2. Confirmation that the PR/MR description was updated, or that we left a comment as a fallback, or that the post step was skipped because the source was local / branchless
+3. Summary of elements created (X docs, Y diagrams, Z table rows)
+4. High-risk files requiring careful review
+5. Security findings (if any critical/high)
+6. Architecture concerns (if any breaking changes)
 
 ## Background
 

--- a/codex-plugins/miro/skills/miro-diagram/SKILL.md
+++ b/codex-plugins/miro/skills/miro-diagram/SKILL.md
@@ -28,7 +28,7 @@ Automatically detect or let the user specify:
 2. If description is missing or unclear, ask what they want to diagram
 3. Determine the appropriate diagram type from the description (or ask if ambiguous)
 4. *(Optional, for precise control)* Call `diagram_get_dsl` first to fetch the DSL spec — useful when the user wants a structurally complex diagram and you'd rather author the DSL directly than rely on natural language.
-5. Call `diagram_create` with the board URL, the diagram description, and optionally the diagram type if specified. Set `parent_id` to a frame ID if the diagram should sit inside a frame.
+5. Call `diagram_create` with the board URL, the diagram description, and optionally the diagram type if specified. To place the diagram inside a frame, pass the board URL with `?moveToWidget=<frame_id>` — the tool detects the frame target automatically (no `parent_id` argument exists). When that URL is used, `x` and `y` become coordinates relative to the frame's top-left corner.
 6. Report success with a link to the board
 
 ## Examples
@@ -68,13 +68,16 @@ flowchart TD
     E --> F[Create Account]
 ```
 
-## Positioning on the Board
+## Positioning
 
-Board coordinates use a Cartesian system with center at `(0, 0)`. Positive X goes right, positive Y goes down.
+Two coordinate systems depending on whether the URL targets a frame:
 
-**Spacing recommendations** when placing multiple items:
+- **Board-level** (URL has no `moveToWidget`): Cartesian with the board center at `(0, 0)`. Positive x goes right, positive y goes down.
+- **Frame target** (URL has `?moveToWidget=<frame_id>`): coordinates are relative to the frame's top-left corner; `(0, 0)` is the frame's top-left. The diagram must fit within the frame's width and height. Targets that point at a non-frame item are silently ignored, so the diagram lands on the board.
+
+**Spacing recommendations** when placing multiple items at the board level:
 - Diagrams: 2000–3000 units apart
 - Documents: 500–1000 units apart
 - Tables: 1500–2000 units apart
 
-To place a diagram inside a frame, set `parent_id` to the frame's ID.
+When placing multiple items inside a single frame, fetch the frame's geometry first (e.g. via `context_get` with the frame URL) and lay them out in a grid that fits within the frame's width and height.

--- a/codex-plugins/miro/skills/miro-doc/SKILL.md
+++ b/codex-plugins/miro/skills/miro-doc/SKILL.md
@@ -30,8 +30,13 @@ The document supports:
    - If it's actual document content, use it directly
    - If it's a topic/request, generate appropriate document content
 3. If content is missing, ask what document they want to create
-4. Call `doc_create` with the board URL and the markdown content. Set `parent_id` to a frame ID if the document should sit inside a frame.
+4. Call `doc_create` with the board URL and the markdown content. To place the document inside a frame, pass the board URL with `?moveToWidget=<frame_id>` — the tool will detect the frame target automatically (no `parent_id` argument exists). When that URL is used, `x` and `y` become coordinates relative to the frame's top-left corner; pick values that fit inside the frame's width and height (default doc width is 800px).
 5. Report success with a link to the board
+
+## Coordinates
+
+- Board-level (URL has no `moveToWidget`): `x=0, y=0` is the board center.
+- Frame target (URL has `?moveToWidget=<frame_id>`): `x=0, y=0` is the frame's top-left corner. The doc's top-left is placed at the given `x, y`, and the doc must fit inside the frame's width and height. Targets that point at a non-frame item (sticky note, shape, diagram) are silently ignored, so the doc lands on the board.
 
 ## Examples
 

--- a/codex-plugins/miro/skills/miro-table/SKILL.md
+++ b/codex-plugins/miro/skills/miro-table/SKILL.md
@@ -25,8 +25,13 @@ Identify from the user's request:
 3. Based on the table purpose, suggest appropriate columns:
    - Propose a default column structure
    - Let user customize or accept defaults
-4. Call `table_create` with the board URL, table name, and column definitions. Set `parent_id` to a frame ID if the table should sit inside a frame.
+4. Call `table_create` with the board URL, table name, and column definitions. To place the table inside a frame, pass the board URL with `?moveToWidget=<frame_id>` — the tool detects the frame target automatically (no `parent_id` argument exists). When that URL is used, `x` and `y` become coordinates relative to the frame's top-left corner; the table must fit within the frame's width and height.
 5. Report success and offer to add initial rows
+
+## Coordinates
+
+- **Board-level** (URL has no `moveToWidget`): board center is `(0, 0)`.
+- **Frame target** (URL has `?moveToWidget=<frame_id>`): `(0, 0)` is the frame's top-left corner. Targets that point at a non-frame item are silently ignored, so the table lands on the board.
 
 ## Common Table Templates
 

--- a/copilot-cowork-plugins/miro/skills/miro-code-review/SKILL.md
+++ b/copilot-cowork-plugins/miro/skills/miro-code-review/SKILL.md
@@ -1,38 +1,69 @@
 ---
 name: miro-code-review
-description: Use when the user wants to create a visual code review on a Miro board from a GitHub PR (current or external repo), local uncommitted changes, or a branch comparison — produces a file-changes table, summary/architecture/security docs, and architecture diagrams.
+description: Use when the user wants to create a visual code review on a Miro board from a pull/merge request (GitHub, GitLab, or any forge), local uncommitted changes, or a branch comparison — produces a file-changes table, summary/architecture/security docs, and architecture diagrams, then links them back from the PR/MR.
 ---
 
 # Visual Code Review
 
-Generate a comprehensive visual code review on a Miro board from GitHub PRs, local changes, or branch comparisons. Includes architecture analysis, security review, and optionally enriches with enterprise documentation.
+Generate a comprehensive visual code review on a Miro board from a pull/merge request, local changes, or a branch comparison. Includes architecture analysis, security review, and optionally enriches with enterprise documentation. After the artifacts are created, link them back from the PR/MR description so reviewers can find them without leaving their forge.
 
-The user provides a Miro board URL plus one source: a PR number, `owner/repo#number`, a full PR URL, the keyword "local changes", or a branch name to compare against main.
+The user provides a Miro board URL plus one source: a PR/MR number, `owner/repo#number` (or `group/project!number`), a full PR/MR URL, the keyword "local changes", or a branch name to compare against the default branch. The skill is platform-agnostic: it detects the forge from the URL or the configured git remote and uses whichever CLI is available locally.
 
 ## Workflow
 
 ### 1. Identify the source from the user's request
 
-Determine the source type:
-- A bare number → GitHub PR in the current repo
-- `owner/repo#number` → External GitHub PR
-- A GitHub URL → Extract owner, repo, and PR number from the URL
-- "local changes" / uncommitted work → Local changes
-- A branch name → Branch comparison against main
+Determine the source type and infer the platform from the URL or configured git remote:
+
+- A bare number → PR/MR in the current repo (infer the platform from the configured git remote: `git remote get-url origin`)
+- `owner/repo#number` (or `group/project!number` for GitLab-style) → PR/MR in an external repo on the same platform as the current remote, unless a host is given
+- A full URL → extract host, owner/group, repo/project, and PR/MR number from the URL; the host determines the platform
+- "local changes" / uncommitted work → local diff only, no PR
+- A branch name → local diff against the default branch (`main` or whatever the remote shows as default)
+
+#### Tool selection
+
+Pick the CLI based on what's installed and what the source points at. Do not assume `gh`. Run `command -v <cli>` to check availability before invoking:
+
+- GitHub URLs / `github.com` remote → `gh` CLI if available
+- GitLab URLs / `gitlab.com` or self-hosted GitLab → `glab` CLI if available
+- If no first-party CLI is available for the detected platform, fall back to authenticated REST via `curl` using whatever credentials the user already has configured (e.g. `~/.netrc`, env var tokens like `$GITHUB_TOKEN`, `$GITLAB_TOKEN`)
+- For local / branch-comparison sources, plain `git` is sufficient — no platform CLI needed
+
+State the detected platform and tool in chat output before proceeding.
 
 ### 2. Extract Changes
 
-**For GitHub PR (current repo):**
+Fetch two things, regardless of platform:
+
+1. **Metadata**: title, description/body, author, list of changed files with additions/deletions per file
+2. **Unified diff** of the change
+
+Use whichever CLI matches the platform detected in §1; the JSON/text shape will differ between forges — normalize fields downstream.
+
+**GitHub example (`gh`):**
 ```bash
+# Current repo
 gh pr view $PR_NUMBER --json title,body,author,files,additions,deletions
 gh pr diff $PR_NUMBER
-```
 
-**For GitHub PR (external repo):**
-```bash
+# External repo
 gh pr view $PR_NUMBER --repo $OWNER/$REPO --json title,body,author,files,additions,deletions
 gh pr diff $PR_NUMBER --repo $OWNER/$REPO
 ```
+
+**GitLab example (`glab`):**
+```bash
+# Current project
+glab mr view $MR_NUMBER -F json
+glab mr diff $MR_NUMBER
+
+# External project
+glab mr view $MR_NUMBER -R $GROUP/$PROJECT -F json
+glab mr diff $MR_NUMBER -R $GROUP/$PROJECT
+```
+
+**REST fallback (any platform):** issue an authenticated `curl` to the platform's REST endpoint for the PR/MR and its diff. Use the user's configured token (`$GITHUB_TOKEN`, `$GITLAB_TOKEN`, etc.) and pass `Accept: application/vnd.github.v3.diff` (or platform equivalent) for the diff.
 
 **For Local Changes:**
 ```bash
@@ -42,8 +73,9 @@ git diff HEAD
 
 **For Branch Comparison:**
 ```bash
-git log main..HEAD --oneline
-git diff main...HEAD
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+git log $DEFAULT_BRANCH..HEAD --oneline
+git diff $DEFAULT_BRANCH...HEAD
 ```
 
 ### 3. Analyze Changes
@@ -275,14 +307,75 @@ Adjust starting x based on actual number of documents created.
 - Dependencies between changed files
 - Trust boundaries (for security-relevant changes)
 
+### 6. Post link back to PR/MR
+
+Once the artifacts are created, surface the link from the PR/MR itself so reviewers see it without leaving their forge.
+
+**Skip this step entirely** when:
+- The source is "local changes"
+- The source is a branch with no associated open PR/MR
+
+In those cases the link is reported only in chat output (see §Output below).
+
+#### Block format
+
+Append a delimited block to the existing PR/MR description. Reuse the same delimiters on every run so the block can be replaced cleanly:
+
+```
+<!-- miro-pr-docs:start -->
+## PR documentation
+
+PR details on Miro: <link>
+
+- <X> documents, <Y> diagrams, <Z> table rows
+- High-risk files: <count>
+- Security findings: <count>
+<!-- miro-pr-docs:end -->
+```
+
+**Link rules:**
+- If the original Miro URL contained `moveToWidget=<frameId>`, reuse that exact URL — clicking opens straight to the frame
+- Otherwise use the plain board URL
+
+**Idempotency:**
+- If the description already contains the `<!-- miro-pr-docs:start -->` … `<!-- miro-pr-docs:end -->` markers, replace the contents in place
+- Otherwise append the block at the end of the existing description, preserving everything else verbatim
+- Never overwrite the user-authored portion of the description
+
+#### Update the description
+
+Use the same CLI selection from §1. Read the current body, splice the new block, write it back.
+
+**GitHub example (`gh`):**
+```bash
+# Read current body
+BODY=$(gh pr view $PR_NUMBER --json body -q .body)
+# (splice: replace existing block or append) → produce $NEW_BODY
+gh pr edit $PR_NUMBER --body "$NEW_BODY"
+```
+
+**GitLab example (`glab`):**
+```bash
+BODY=$(glab mr view $MR_NUMBER -F json | jq -r .description)
+# (splice) → $NEW_BODY
+glab mr update $MR_NUMBER --description "$NEW_BODY"
+```
+
+**REST fallback:** read and PATCH the PR/MR body via the platform's REST API with the user's token.
+
+#### Permission failure fallback
+
+If editing the description fails because the user lacks permission (for example, when reviewing someone else's PR), post the same block as a single PR/MR comment instead. Mention this fallback in the chat output so the user knows the description was not changed.
+
 ## Output
 
 After completion, provide:
-1. Link to the Miro board
-2. Summary of elements created (X docs, Y diagrams, Z table rows)
-3. High-risk files requiring careful review
-4. Security findings (if any critical/high)
-5. Architecture concerns (if any breaking changes)
+1. Link to the Miro board (or frame, if `moveToWidget` was provided)
+2. Confirmation that the PR/MR description was updated, or that we left a comment as a fallback, or that the post step was skipped because the source was local / branchless
+3. Summary of elements created (X docs, Y diagrams, Z table rows)
+4. High-risk files requiring careful review
+5. Security findings (if any critical/high)
+6. Architecture concerns (if any breaking changes)
 
 ## Background
 

--- a/copilot-cowork-plugins/miro/skills/miro-diagram/SKILL.md
+++ b/copilot-cowork-plugins/miro/skills/miro-diagram/SKILL.md
@@ -28,7 +28,7 @@ Automatically detect or let the user specify:
 2. If description is missing or unclear, ask what they want to diagram
 3. Determine the appropriate diagram type from the description (or ask if ambiguous)
 4. *(Optional, for precise control)* Call `diagram_get_dsl` first to fetch the DSL spec — useful when the user wants a structurally complex diagram and you'd rather author the DSL directly than rely on natural language.
-5. Call `diagram_create` with the board URL, the diagram description, and optionally the diagram type if specified. Set `parent_id` to a frame ID if the diagram should sit inside a frame.
+5. Call `diagram_create` with the board URL, the diagram description, and optionally the diagram type if specified. To place the diagram inside a frame, pass the board URL with `?moveToWidget=<frame_id>` — the tool detects the frame target automatically (no `parent_id` argument exists). When that URL is used, `x` and `y` become coordinates relative to the frame's top-left corner.
 6. Report success with a link to the board
 
 ## Examples
@@ -68,13 +68,16 @@ flowchart TD
     E --> F[Create Account]
 ```
 
-## Positioning on the Board
+## Positioning
 
-Board coordinates use a Cartesian system with center at `(0, 0)`. Positive X goes right, positive Y goes down.
+Two coordinate systems depending on whether the URL targets a frame:
 
-**Spacing recommendations** when placing multiple items:
+- **Board-level** (URL has no `moveToWidget`): Cartesian with the board center at `(0, 0)`. Positive x goes right, positive y goes down.
+- **Frame target** (URL has `?moveToWidget=<frame_id>`): coordinates are relative to the frame's top-left corner; `(0, 0)` is the frame's top-left. The diagram must fit within the frame's width and height. Targets that point at a non-frame item are silently ignored, so the diagram lands on the board.
+
+**Spacing recommendations** when placing multiple items at the board level:
 - Diagrams: 2000–3000 units apart
 - Documents: 500–1000 units apart
 - Tables: 1500–2000 units apart
 
-To place a diagram inside a frame, set `parent_id` to the frame's ID.
+When placing multiple items inside a single frame, fetch the frame's geometry first (e.g. via `context_get` with the frame URL) and lay them out in a grid that fits within the frame's width and height.

--- a/copilot-cowork-plugins/miro/skills/miro-doc/SKILL.md
+++ b/copilot-cowork-plugins/miro/skills/miro-doc/SKILL.md
@@ -30,8 +30,13 @@ The document supports:
    - If it's actual document content, use it directly
    - If it's a topic/request, generate appropriate document content
 3. If content is missing, ask what document they want to create
-4. Call `doc_create` with the board URL and the markdown content. Set `parent_id` to a frame ID if the document should sit inside a frame.
+4. Call `doc_create` with the board URL and the markdown content. To place the document inside a frame, pass the board URL with `?moveToWidget=<frame_id>` — the tool will detect the frame target automatically (no `parent_id` argument exists). When that URL is used, `x` and `y` become coordinates relative to the frame's top-left corner; pick values that fit inside the frame's width and height (default doc width is 800px).
 5. Report success with a link to the board
+
+## Coordinates
+
+- Board-level (URL has no `moveToWidget`): `x=0, y=0` is the board center.
+- Frame target (URL has `?moveToWidget=<frame_id>`): `x=0, y=0` is the frame's top-left corner. The doc's top-left is placed at the given `x, y`, and the doc must fit inside the frame's width and height. Targets that point at a non-frame item (sticky note, shape, diagram) are silently ignored, so the doc lands on the board.
 
 ## Examples
 

--- a/copilot-cowork-plugins/miro/skills/miro-table/SKILL.md
+++ b/copilot-cowork-plugins/miro/skills/miro-table/SKILL.md
@@ -25,8 +25,13 @@ Identify from the user's request:
 3. Based on the table purpose, suggest appropriate columns:
    - Propose a default column structure
    - Let user customize or accept defaults
-4. Call `table_create` with the board URL, table name, and column definitions. Set `parent_id` to a frame ID if the table should sit inside a frame.
+4. Call `table_create` with the board URL, table name, and column definitions. To place the table inside a frame, pass the board URL with `?moveToWidget=<frame_id>` — the tool detects the frame target automatically (no `parent_id` argument exists). When that URL is used, `x` and `y` become coordinates relative to the frame's top-left corner; the table must fit within the frame's width and height.
 5. Report success and offer to add initial rows
+
+## Coordinates
+
+- **Board-level** (URL has no `moveToWidget`): board center is `(0, 0)`.
+- **Frame target** (URL has `?moveToWidget=<frame_id>`): `(0, 0)` is the frame's top-left corner. Targets that point at a non-frame item are silently ignored, so the table lands on the board.
 
 ## Common Table Templates
 

--- a/cursor-plugins/miro/skills/miro-code-review/SKILL.md
+++ b/cursor-plugins/miro/skills/miro-code-review/SKILL.md
@@ -1,38 +1,69 @@
 ---
 name: miro-code-review
-description: Use when the user wants to create a visual code review on a Miro board from a GitHub PR (current or external repo), local uncommitted changes, or a branch comparison — produces a file-changes table, summary/architecture/security docs, and architecture diagrams.
+description: Use when the user wants to create a visual code review on a Miro board from a pull/merge request (GitHub, GitLab, or any forge), local uncommitted changes, or a branch comparison — produces a file-changes table, summary/architecture/security docs, and architecture diagrams, then links them back from the PR/MR.
 ---
 
 # Visual Code Review
 
-Generate a comprehensive visual code review on a Miro board from GitHub PRs, local changes, or branch comparisons. Includes architecture analysis, security review, and optionally enriches with enterprise documentation.
+Generate a comprehensive visual code review on a Miro board from a pull/merge request, local changes, or a branch comparison. Includes architecture analysis, security review, and optionally enriches with enterprise documentation. After the artifacts are created, link them back from the PR/MR description so reviewers can find them without leaving their forge.
 
-The user provides a Miro board URL plus one source: a PR number, `owner/repo#number`, a full PR URL, the keyword "local changes", or a branch name to compare against main.
+The user provides a Miro board URL plus one source: a PR/MR number, `owner/repo#number` (or `group/project!number`), a full PR/MR URL, the keyword "local changes", or a branch name to compare against the default branch. The skill is platform-agnostic: it detects the forge from the URL or the configured git remote and uses whichever CLI is available locally.
 
 ## Workflow
 
 ### 1. Identify the source from the user's request
 
-Determine the source type:
-- A bare number → GitHub PR in the current repo
-- `owner/repo#number` → External GitHub PR
-- A GitHub URL → Extract owner, repo, and PR number from the URL
-- "local changes" / uncommitted work → Local changes
-- A branch name → Branch comparison against main
+Determine the source type and infer the platform from the URL or configured git remote:
+
+- A bare number → PR/MR in the current repo (infer the platform from the configured git remote: `git remote get-url origin`)
+- `owner/repo#number` (or `group/project!number` for GitLab-style) → PR/MR in an external repo on the same platform as the current remote, unless a host is given
+- A full URL → extract host, owner/group, repo/project, and PR/MR number from the URL; the host determines the platform
+- "local changes" / uncommitted work → local diff only, no PR
+- A branch name → local diff against the default branch (`main` or whatever the remote shows as default)
+
+#### Tool selection
+
+Pick the CLI based on what's installed and what the source points at. Do not assume `gh`. Run `command -v <cli>` to check availability before invoking:
+
+- GitHub URLs / `github.com` remote → `gh` CLI if available
+- GitLab URLs / `gitlab.com` or self-hosted GitLab → `glab` CLI if available
+- If no first-party CLI is available for the detected platform, fall back to authenticated REST via `curl` using whatever credentials the user already has configured (e.g. `~/.netrc`, env var tokens like `$GITHUB_TOKEN`, `$GITLAB_TOKEN`)
+- For local / branch-comparison sources, plain `git` is sufficient — no platform CLI needed
+
+State the detected platform and tool in chat output before proceeding.
 
 ### 2. Extract Changes
 
-**For GitHub PR (current repo):**
+Fetch two things, regardless of platform:
+
+1. **Metadata**: title, description/body, author, list of changed files with additions/deletions per file
+2. **Unified diff** of the change
+
+Use whichever CLI matches the platform detected in §1; the JSON/text shape will differ between forges — normalize fields downstream.
+
+**GitHub example (`gh`):**
 ```bash
+# Current repo
 gh pr view $PR_NUMBER --json title,body,author,files,additions,deletions
 gh pr diff $PR_NUMBER
-```
 
-**For GitHub PR (external repo):**
-```bash
+# External repo
 gh pr view $PR_NUMBER --repo $OWNER/$REPO --json title,body,author,files,additions,deletions
 gh pr diff $PR_NUMBER --repo $OWNER/$REPO
 ```
+
+**GitLab example (`glab`):**
+```bash
+# Current project
+glab mr view $MR_NUMBER -F json
+glab mr diff $MR_NUMBER
+
+# External project
+glab mr view $MR_NUMBER -R $GROUP/$PROJECT -F json
+glab mr diff $MR_NUMBER -R $GROUP/$PROJECT
+```
+
+**REST fallback (any platform):** issue an authenticated `curl` to the platform's REST endpoint for the PR/MR and its diff. Use the user's configured token (`$GITHUB_TOKEN`, `$GITLAB_TOKEN`, etc.) and pass `Accept: application/vnd.github.v3.diff` (or platform equivalent) for the diff.
 
 **For Local Changes:**
 ```bash
@@ -42,8 +73,9 @@ git diff HEAD
 
 **For Branch Comparison:**
 ```bash
-git log main..HEAD --oneline
-git diff main...HEAD
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+git log $DEFAULT_BRANCH..HEAD --oneline
+git diff $DEFAULT_BRANCH...HEAD
 ```
 
 ### 3. Analyze Changes
@@ -275,14 +307,75 @@ Adjust starting x based on actual number of documents created.
 - Dependencies between changed files
 - Trust boundaries (for security-relevant changes)
 
+### 6. Post link back to PR/MR
+
+Once the artifacts are created, surface the link from the PR/MR itself so reviewers see it without leaving their forge.
+
+**Skip this step entirely** when:
+- The source is "local changes"
+- The source is a branch with no associated open PR/MR
+
+In those cases the link is reported only in chat output (see §Output below).
+
+#### Block format
+
+Append a delimited block to the existing PR/MR description. Reuse the same delimiters on every run so the block can be replaced cleanly:
+
+```
+<!-- miro-pr-docs:start -->
+## PR documentation
+
+PR details on Miro: <link>
+
+- <X> documents, <Y> diagrams, <Z> table rows
+- High-risk files: <count>
+- Security findings: <count>
+<!-- miro-pr-docs:end -->
+```
+
+**Link rules:**
+- If the original Miro URL contained `moveToWidget=<frameId>`, reuse that exact URL — clicking opens straight to the frame
+- Otherwise use the plain board URL
+
+**Idempotency:**
+- If the description already contains the `<!-- miro-pr-docs:start -->` … `<!-- miro-pr-docs:end -->` markers, replace the contents in place
+- Otherwise append the block at the end of the existing description, preserving everything else verbatim
+- Never overwrite the user-authored portion of the description
+
+#### Update the description
+
+Use the same CLI selection from §1. Read the current body, splice the new block, write it back.
+
+**GitHub example (`gh`):**
+```bash
+# Read current body
+BODY=$(gh pr view $PR_NUMBER --json body -q .body)
+# (splice: replace existing block or append) → produce $NEW_BODY
+gh pr edit $PR_NUMBER --body "$NEW_BODY"
+```
+
+**GitLab example (`glab`):**
+```bash
+BODY=$(glab mr view $MR_NUMBER -F json | jq -r .description)
+# (splice) → $NEW_BODY
+glab mr update $MR_NUMBER --description "$NEW_BODY"
+```
+
+**REST fallback:** read and PATCH the PR/MR body via the platform's REST API with the user's token.
+
+#### Permission failure fallback
+
+If editing the description fails because the user lacks permission (for example, when reviewing someone else's PR), post the same block as a single PR/MR comment instead. Mention this fallback in the chat output so the user knows the description was not changed.
+
 ## Output
 
 After completion, provide:
-1. Link to the Miro board
-2. Summary of elements created (X docs, Y diagrams, Z table rows)
-3. High-risk files requiring careful review
-4. Security findings (if any critical/high)
-5. Architecture concerns (if any breaking changes)
+1. Link to the Miro board (or frame, if `moveToWidget` was provided)
+2. Confirmation that the PR/MR description was updated, or that we left a comment as a fallback, or that the post step was skipped because the source was local / branchless
+3. Summary of elements created (X docs, Y diagrams, Z table rows)
+4. High-risk files requiring careful review
+5. Security findings (if any critical/high)
+6. Architecture concerns (if any breaking changes)
 
 ## Background
 

--- a/cursor-plugins/miro/skills/miro-diagram/SKILL.md
+++ b/cursor-plugins/miro/skills/miro-diagram/SKILL.md
@@ -28,7 +28,7 @@ Automatically detect or let the user specify:
 2. If description is missing or unclear, ask what they want to diagram
 3. Determine the appropriate diagram type from the description (or ask if ambiguous)
 4. *(Optional, for precise control)* Call `diagram_get_dsl` first to fetch the DSL spec — useful when the user wants a structurally complex diagram and you'd rather author the DSL directly than rely on natural language.
-5. Call `diagram_create` with the board URL, the diagram description, and optionally the diagram type if specified. Set `parent_id` to a frame ID if the diagram should sit inside a frame.
+5. Call `diagram_create` with the board URL, the diagram description, and optionally the diagram type if specified. To place the diagram inside a frame, pass the board URL with `?moveToWidget=<frame_id>` — the tool detects the frame target automatically (no `parent_id` argument exists). When that URL is used, `x` and `y` become coordinates relative to the frame's top-left corner.
 6. Report success with a link to the board
 
 ## Examples
@@ -68,13 +68,16 @@ flowchart TD
     E --> F[Create Account]
 ```
 
-## Positioning on the Board
+## Positioning
 
-Board coordinates use a Cartesian system with center at `(0, 0)`. Positive X goes right, positive Y goes down.
+Two coordinate systems depending on whether the URL targets a frame:
 
-**Spacing recommendations** when placing multiple items:
+- **Board-level** (URL has no `moveToWidget`): Cartesian with the board center at `(0, 0)`. Positive x goes right, positive y goes down.
+- **Frame target** (URL has `?moveToWidget=<frame_id>`): coordinates are relative to the frame's top-left corner; `(0, 0)` is the frame's top-left. The diagram must fit within the frame's width and height. Targets that point at a non-frame item are silently ignored, so the diagram lands on the board.
+
+**Spacing recommendations** when placing multiple items at the board level:
 - Diagrams: 2000–3000 units apart
 - Documents: 500–1000 units apart
 - Tables: 1500–2000 units apart
 
-To place a diagram inside a frame, set `parent_id` to the frame's ID.
+When placing multiple items inside a single frame, fetch the frame's geometry first (e.g. via `context_get` with the frame URL) and lay them out in a grid that fits within the frame's width and height.

--- a/cursor-plugins/miro/skills/miro-doc/SKILL.md
+++ b/cursor-plugins/miro/skills/miro-doc/SKILL.md
@@ -30,8 +30,13 @@ The document supports:
    - If it's actual document content, use it directly
    - If it's a topic/request, generate appropriate document content
 3. If content is missing, ask what document they want to create
-4. Call `doc_create` with the board URL and the markdown content. Set `parent_id` to a frame ID if the document should sit inside a frame.
+4. Call `doc_create` with the board URL and the markdown content. To place the document inside a frame, pass the board URL with `?moveToWidget=<frame_id>` — the tool will detect the frame target automatically (no `parent_id` argument exists). When that URL is used, `x` and `y` become coordinates relative to the frame's top-left corner; pick values that fit inside the frame's width and height (default doc width is 800px).
 5. Report success with a link to the board
+
+## Coordinates
+
+- Board-level (URL has no `moveToWidget`): `x=0, y=0` is the board center.
+- Frame target (URL has `?moveToWidget=<frame_id>`): `x=0, y=0` is the frame's top-left corner. The doc's top-left is placed at the given `x, y`, and the doc must fit inside the frame's width and height. Targets that point at a non-frame item (sticky note, shape, diagram) are silently ignored, so the doc lands on the board.
 
 ## Examples
 

--- a/cursor-plugins/miro/skills/miro-table/SKILL.md
+++ b/cursor-plugins/miro/skills/miro-table/SKILL.md
@@ -25,8 +25,13 @@ Identify from the user's request:
 3. Based on the table purpose, suggest appropriate columns:
    - Propose a default column structure
    - Let user customize or accept defaults
-4. Call `table_create` with the board URL, table name, and column definitions. Set `parent_id` to a frame ID if the table should sit inside a frame.
+4. Call `table_create` with the board URL, table name, and column definitions. To place the table inside a frame, pass the board URL with `?moveToWidget=<frame_id>` — the tool detects the frame target automatically (no `parent_id` argument exists). When that URL is used, `x` and `y` become coordinates relative to the frame's top-left corner; the table must fit within the frame's width and height.
 5. Report success and offer to add initial rows
+
+## Coordinates
+
+- **Board-level** (URL has no `moveToWidget`): board center is `(0, 0)`.
+- **Frame target** (URL has `?moveToWidget=<frame_id>`): `(0, 0)` is the frame's top-left corner. Targets that point at a non-frame item are silently ignored, so the table lands on the board.
 
 ## Common Table Templates
 

--- a/skills/miro-code-review/SKILL.md
+++ b/skills/miro-code-review/SKILL.md
@@ -1,38 +1,69 @@
 ---
 name: miro-code-review
-description: Use when the user wants to create a visual code review on a Miro board from a GitHub PR (current or external repo), local uncommitted changes, or a branch comparison — produces a file-changes table, summary/architecture/security docs, and architecture diagrams.
+description: Use when the user wants to create a visual code review on a Miro board from a pull/merge request (GitHub, GitLab, or any forge), local uncommitted changes, or a branch comparison — produces a file-changes table, summary/architecture/security docs, and architecture diagrams, then links them back from the PR/MR.
 ---
 
 # Visual Code Review
 
-Generate a comprehensive visual code review on a Miro board from GitHub PRs, local changes, or branch comparisons. Includes architecture analysis, security review, and optionally enriches with enterprise documentation.
+Generate a comprehensive visual code review on a Miro board from a pull/merge request, local changes, or a branch comparison. Includes architecture analysis, security review, and optionally enriches with enterprise documentation. After the artifacts are created, link them back from the PR/MR description so reviewers can find them without leaving their forge.
 
-The user provides a Miro board URL plus one source: a PR number, `owner/repo#number`, a full PR URL, the keyword "local changes", or a branch name to compare against main.
+The user provides a Miro board URL plus one source: a PR/MR number, `owner/repo#number` (or `group/project!number`), a full PR/MR URL, the keyword "local changes", or a branch name to compare against the default branch. The skill is platform-agnostic: it detects the forge from the URL or the configured git remote and uses whichever CLI is available locally.
 
 ## Workflow
 
 ### 1. Identify the source from the user's request
 
-Determine the source type:
-- A bare number → GitHub PR in the current repo
-- `owner/repo#number` → External GitHub PR
-- A GitHub URL → Extract owner, repo, and PR number from the URL
-- "local changes" / uncommitted work → Local changes
-- A branch name → Branch comparison against main
+Determine the source type and infer the platform from the URL or configured git remote:
+
+- A bare number → PR/MR in the current repo (infer the platform from the configured git remote: `git remote get-url origin`)
+- `owner/repo#number` (or `group/project!number` for GitLab-style) → PR/MR in an external repo on the same platform as the current remote, unless a host is given
+- A full URL → extract host, owner/group, repo/project, and PR/MR number from the URL; the host determines the platform
+- "local changes" / uncommitted work → local diff only, no PR
+- A branch name → local diff against the default branch (`main` or whatever the remote shows as default)
+
+#### Tool selection
+
+Pick the CLI based on what's installed and what the source points at. Do not assume `gh`. Run `command -v <cli>` to check availability before invoking:
+
+- GitHub URLs / `github.com` remote → `gh` CLI if available
+- GitLab URLs / `gitlab.com` or self-hosted GitLab → `glab` CLI if available
+- If no first-party CLI is available for the detected platform, fall back to authenticated REST via `curl` using whatever credentials the user already has configured (e.g. `~/.netrc`, env var tokens like `$GITHUB_TOKEN`, `$GITLAB_TOKEN`)
+- For local / branch-comparison sources, plain `git` is sufficient — no platform CLI needed
+
+State the detected platform and tool in chat output before proceeding.
 
 ### 2. Extract Changes
 
-**For GitHub PR (current repo):**
+Fetch two things, regardless of platform:
+
+1. **Metadata**: title, description/body, author, list of changed files with additions/deletions per file
+2. **Unified diff** of the change
+
+Use whichever CLI matches the platform detected in §1; the JSON/text shape will differ between forges — normalize fields downstream.
+
+**GitHub example (`gh`):**
 ```bash
+# Current repo
 gh pr view $PR_NUMBER --json title,body,author,files,additions,deletions
 gh pr diff $PR_NUMBER
-```
 
-**For GitHub PR (external repo):**
-```bash
+# External repo
 gh pr view $PR_NUMBER --repo $OWNER/$REPO --json title,body,author,files,additions,deletions
 gh pr diff $PR_NUMBER --repo $OWNER/$REPO
 ```
+
+**GitLab example (`glab`):**
+```bash
+# Current project
+glab mr view $MR_NUMBER -F json
+glab mr diff $MR_NUMBER
+
+# External project
+glab mr view $MR_NUMBER -R $GROUP/$PROJECT -F json
+glab mr diff $MR_NUMBER -R $GROUP/$PROJECT
+```
+
+**REST fallback (any platform):** issue an authenticated `curl` to the platform's REST endpoint for the PR/MR and its diff. Use the user's configured token (`$GITHUB_TOKEN`, `$GITLAB_TOKEN`, etc.) and pass `Accept: application/vnd.github.v3.diff` (or platform equivalent) for the diff.
 
 **For Local Changes:**
 ```bash
@@ -42,8 +73,9 @@ git diff HEAD
 
 **For Branch Comparison:**
 ```bash
-git log main..HEAD --oneline
-git diff main...HEAD
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+git log $DEFAULT_BRANCH..HEAD --oneline
+git diff $DEFAULT_BRANCH...HEAD
 ```
 
 ### 3. Analyze Changes
@@ -275,14 +307,75 @@ Adjust starting x based on actual number of documents created.
 - Dependencies between changed files
 - Trust boundaries (for security-relevant changes)
 
+### 6. Post link back to PR/MR
+
+Once the artifacts are created, surface the link from the PR/MR itself so reviewers see it without leaving their forge.
+
+**Skip this step entirely** when:
+- The source is "local changes"
+- The source is a branch with no associated open PR/MR
+
+In those cases the link is reported only in chat output (see §Output below).
+
+#### Block format
+
+Append a delimited block to the existing PR/MR description. Reuse the same delimiters on every run so the block can be replaced cleanly:
+
+```
+<!-- miro-pr-docs:start -->
+## PR documentation
+
+PR details on Miro: <link>
+
+- <X> documents, <Y> diagrams, <Z> table rows
+- High-risk files: <count>
+- Security findings: <count>
+<!-- miro-pr-docs:end -->
+```
+
+**Link rules:**
+- If the original Miro URL contained `moveToWidget=<frameId>`, reuse that exact URL — clicking opens straight to the frame
+- Otherwise use the plain board URL
+
+**Idempotency:**
+- If the description already contains the `<!-- miro-pr-docs:start -->` … `<!-- miro-pr-docs:end -->` markers, replace the contents in place
+- Otherwise append the block at the end of the existing description, preserving everything else verbatim
+- Never overwrite the user-authored portion of the description
+
+#### Update the description
+
+Use the same CLI selection from §1. Read the current body, splice the new block, write it back.
+
+**GitHub example (`gh`):**
+```bash
+# Read current body
+BODY=$(gh pr view $PR_NUMBER --json body -q .body)
+# (splice: replace existing block or append) → produce $NEW_BODY
+gh pr edit $PR_NUMBER --body "$NEW_BODY"
+```
+
+**GitLab example (`glab`):**
+```bash
+BODY=$(glab mr view $MR_NUMBER -F json | jq -r .description)
+# (splice) → $NEW_BODY
+glab mr update $MR_NUMBER --description "$NEW_BODY"
+```
+
+**REST fallback:** read and PATCH the PR/MR body via the platform's REST API with the user's token.
+
+#### Permission failure fallback
+
+If editing the description fails because the user lacks permission (for example, when reviewing someone else's PR), post the same block as a single PR/MR comment instead. Mention this fallback in the chat output so the user knows the description was not changed.
+
 ## Output
 
 After completion, provide:
-1. Link to the Miro board
-2. Summary of elements created (X docs, Y diagrams, Z table rows)
-3. High-risk files requiring careful review
-4. Security findings (if any critical/high)
-5. Architecture concerns (if any breaking changes)
+1. Link to the Miro board (or frame, if `moveToWidget` was provided)
+2. Confirmation that the PR/MR description was updated, or that we left a comment as a fallback, or that the post step was skipped because the source was local / branchless
+3. Summary of elements created (X docs, Y diagrams, Z table rows)
+4. High-risk files requiring careful review
+5. Security findings (if any critical/high)
+6. Architecture concerns (if any breaking changes)
 
 ## Background
 

--- a/skills/miro-diagram/SKILL.md
+++ b/skills/miro-diagram/SKILL.md
@@ -28,7 +28,7 @@ Automatically detect or let the user specify:
 2. If description is missing or unclear, ask what they want to diagram
 3. Determine the appropriate diagram type from the description (or ask if ambiguous)
 4. *(Optional, for precise control)* Call `diagram_get_dsl` first to fetch the DSL spec — useful when the user wants a structurally complex diagram and you'd rather author the DSL directly than rely on natural language.
-5. Call `diagram_create` with the board URL, the diagram description, and optionally the diagram type if specified. Set `parent_id` to a frame ID if the diagram should sit inside a frame.
+5. Call `diagram_create` with the board URL, the diagram description, and optionally the diagram type if specified. To place the diagram inside a frame, pass the board URL with `?moveToWidget=<frame_id>` — the tool detects the frame target automatically (no `parent_id` argument exists). When that URL is used, `x` and `y` become coordinates relative to the frame's top-left corner.
 6. Report success with a link to the board
 
 ## Examples
@@ -68,13 +68,16 @@ flowchart TD
     E --> F[Create Account]
 ```
 
-## Positioning on the Board
+## Positioning
 
-Board coordinates use a Cartesian system with center at `(0, 0)`. Positive X goes right, positive Y goes down.
+Two coordinate systems depending on whether the URL targets a frame:
 
-**Spacing recommendations** when placing multiple items:
+- **Board-level** (URL has no `moveToWidget`): Cartesian with the board center at `(0, 0)`. Positive x goes right, positive y goes down.
+- **Frame target** (URL has `?moveToWidget=<frame_id>`): coordinates are relative to the frame's top-left corner; `(0, 0)` is the frame's top-left. The diagram must fit within the frame's width and height. Targets that point at a non-frame item are silently ignored, so the diagram lands on the board.
+
+**Spacing recommendations** when placing multiple items at the board level:
 - Diagrams: 2000–3000 units apart
 - Documents: 500–1000 units apart
 - Tables: 1500–2000 units apart
 
-To place a diagram inside a frame, set `parent_id` to the frame's ID.
+When placing multiple items inside a single frame, fetch the frame's geometry first (e.g. via `context_get` with the frame URL) and lay them out in a grid that fits within the frame's width and height.

--- a/skills/miro-doc/SKILL.md
+++ b/skills/miro-doc/SKILL.md
@@ -30,8 +30,13 @@ The document supports:
    - If it's actual document content, use it directly
    - If it's a topic/request, generate appropriate document content
 3. If content is missing, ask what document they want to create
-4. Call `doc_create` with the board URL and the markdown content. Set `parent_id` to a frame ID if the document should sit inside a frame.
+4. Call `doc_create` with the board URL and the markdown content. To place the document inside a frame, pass the board URL with `?moveToWidget=<frame_id>` — the tool will detect the frame target automatically (no `parent_id` argument exists). When that URL is used, `x` and `y` become coordinates relative to the frame's top-left corner; pick values that fit inside the frame's width and height (default doc width is 800px).
 5. Report success with a link to the board
+
+## Coordinates
+
+- Board-level (URL has no `moveToWidget`): `x=0, y=0` is the board center.
+- Frame target (URL has `?moveToWidget=<frame_id>`): `x=0, y=0` is the frame's top-left corner. The doc's top-left is placed at the given `x, y`, and the doc must fit inside the frame's width and height. Targets that point at a non-frame item (sticky note, shape, diagram) are silently ignored, so the doc lands on the board.
 
 ## Examples
 

--- a/skills/miro-table/SKILL.md
+++ b/skills/miro-table/SKILL.md
@@ -25,8 +25,13 @@ Identify from the user's request:
 3. Based on the table purpose, suggest appropriate columns:
    - Propose a default column structure
    - Let user customize or accept defaults
-4. Call `table_create` with the board URL, table name, and column definitions. Set `parent_id` to a frame ID if the table should sit inside a frame.
+4. Call `table_create` with the board URL, table name, and column definitions. To place the table inside a frame, pass the board URL with `?moveToWidget=<frame_id>` — the tool detects the frame target automatically (no `parent_id` argument exists). When that URL is used, `x` and `y` become coordinates relative to the frame's top-left corner; the table must fit within the frame's width and height.
 5. Report success and offer to add initial rows
+
+## Coordinates
+
+- **Board-level** (URL has no `moveToWidget`): board center is `(0, 0)`.
+- **Frame target** (URL has `?moveToWidget=<frame_id>`): `(0, 0)` is the frame's top-left corner. Targets that point at a non-frame item are silently ignored, so the table lands on the board.
 
 ## Common Table Templates
 


### PR DESCRIPTION
## Summary

Fix the bug where artifacts created via Miro skills (docs, diagrams, tables, code review) end up *outside* the frame even when the user provides a board URL with `?moveToWidget=<frame_id>`.

Two root causes in the skills:

1. **`miro-doc`, `miro-diagram`, `miro-table`** told the agent to "set `parent_id` to a frame ID" — but those tools have no `parent_id` argument. The frame target is detected by the server from `moveToWidget` in the URL. Fixed the workflow text and added a Coordinates section explaining the two coordinate systems (board-absolute vs frame top-left relative).

2. **`miro-code-review`** hardcoded board-absolute coordinates like `x=1200, x=2000…` for documents and diagrams. When a frame parent is set, the Miro Platform API treats those values as relative to the frame's top-left, which pushes everything far outside the frame's visible bounds. Rewrote the layout section to:
   - Detect frame-target mode (URL has `moveToWidget` → frame).
   - Fetch frame geometry via `context_get` first.
   - Lay artifacts out in a grid that fits inside the frame's `width × height`, with margins.
   - Fall back to the existing board-absolute layout when no frame is targeted.

The matching MCP server changes (validating that the URL target is actually a frame, propagating parent-update errors, updating tool descriptions to document the two coordinate systems) are in a separate commit on the `mcp-server` repo's `CADE-1768-skills` branch.

## Test plan

- [ ] Open a frame on a staging board, copy URL with `?moveToWidget=<frameId>`.
- [ ] Run `/miro-code-review` against a small PR using that URL — confirm the file-changes table, summary doc, and architecture diagram all land inside the frame and don't overlap.
- [ ] Repeat with a URL pointing to a non-frame item — confirm artifacts land on the board (parent silently dropped, no error).
- [ ] Run `/miro-doc`, `/miro-diagram`, `/miro-table` with frame-target URLs and verify the artifact appears inside the frame at the requested `x, y` (relative to frame top-left).