### PR TITLE
feat(skills): gate miro-code-review artifacts and link file refs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "description": "Secure access to Miro boards. Enables AI to read board context, create diagrams, and generate code with enterprise-grade security.",
       "source": "./claude-plugins/miro",
       "category": "productivity",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "author": {
         "name": "Miro",
         "email": "support@miro.com"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "description": "Secure access to Miro boards. Enables AI to read board context, create diagrams, and generate code with enterprise-grade security.",
       "source": "./claude-plugins/miro",
       "category": "productivity",
-      "version": "1.2.0",
+      "version": "1.2.2",
       "author": {
         "name": "Miro",
         "email": "support@miro.com"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "description": "Secure access to Miro boards. Enables AI to read board context, create diagrams, and generate code with enterprise-grade security.",
       "source": "./claude-plugins/miro",
       "category": "productivity",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "author": {
         "name": "Miro",
         "email": "support@miro.com"

--- a/claude-plugins/miro/.claude-plugin/plugin.json
+++ b/claude-plugins/miro/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "miro",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Secure access to Miro boards. Enables AI to read board context, create diagrams, and generate code with enterprise-grade security.",
   "author": {
     "name": "Miro",

--- a/claude-plugins/miro/.claude-plugin/plugin.json
+++ b/claude-plugins/miro/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "miro",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Secure access to Miro boards. Enables AI to read board context, create diagrams, and generate code with enterprise-grade security.",
   "author": {
     "name": "Miro",

--- a/claude-plugins/miro/.claude-plugin/plugin.json
+++ b/claude-plugins/miro/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "miro",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "description": "Secure access to Miro boards. Enables AI to read board context, create diagrams, and generate code with enterprise-grade security.",
   "author": {
     "name": "Miro",

--- a/claude-plugins/miro/skills/miro-code-review/SKILL.md
+++ b/claude-plugins/miro/skills/miro-code-review/SKILL.md
@@ -103,6 +103,32 @@ LINK_SHA=$(git rev-parse HEAD)
 
 REST fallback: read `head.sha` (GitHub) or `diff_refs.head_sha` (GitLab) from the same JSON payload already fetched above — no extra round-trip needed.
 
+- `LINK_BASE_SHA` — base commit SHA (the PR/MR target tip, or the merge-base for branch comparisons). Required by §5 "Showing change" to render before/after diagrams and to hyperlink "before" nodes to the prior revision:
+
+```bash
+# GitHub
+LINK_BASE_SHA=$(gh pr view $PR_NUMBER --json baseRefOid -q .baseRefOid)
+# external repo: add --repo $OWNER/$REPO
+
+# GitLab
+LINK_BASE_SHA=$(glab mr view $MR_NUMBER -F json | jq -r '.diff_refs.base_sha // .target_branch')
+# external project: add -R $GROUP/$PROJECT
+
+# Local diff (uncommitted): base is the current HEAD itself
+LINK_BASE_SHA=$(git rev-parse HEAD)
+
+# Branch comparison
+LINK_BASE_SHA=$(git merge-base origin/$DEFAULT_BRANCH HEAD)
+```
+
+To extract the pre-change content of a single file (needed when the unified diff alone doesn't carry enough surrounding structure, e.g. class hierarchies):
+
+```bash
+git show $LINK_BASE_SHA:path/to/file
+```
+
+If the base SHA is unreachable (shallow clone, history pruned, target branch not fetched), skip "before" diagrams and announce once in chat: `"base revision unavailable — only 'after' diagrams created"`.
+
 - `LINK_TEMPLATE` — pick by host shape; substitute `{path}` per reference, append `#L<start>-L<end>` line anchors when calling out a specific hunk:
   - GitHub-style: `https://{host}/{owner}/{repo}/blob/{sha}/{path}` (anchor: `#L{a}-L{b}`)
   - GitLab-style: `https://{host}/{group}/{project}/-/blob/{sha}/{path}` (anchor: `#L{a}-{b}`)
@@ -167,7 +193,7 @@ Skip §5 and §6 entirely.
 - **Summary doc** — create when the PR has non-trivial intent that isn't already captured in the PR title/body, OR when ≥ 2 high-risk items need callouts. Skip if it would just paraphrase the PR description.
 - **Architecture doc** — create only if structural changes are detected (new modules, modified public interfaces, dependency changes, breaking changes). Skip otherwise.
 - **Security doc** — create only when security-sensitive paths are touched (see §3 "Security Analysis"). Never create as a checklist-only artifact.
-- **Diagram** — create only when the change involves multi-component flow, control/data path changes, or structural relationships that are hard to grasp from the diff. Explicitly skip diagrams that would be a single node, two nodes with one arrow, or a literal restatement of the diff.
+- **Diagram** — create only when the change involves multi-component flow, control/data path changes, or structural relationships that are hard to grasp from the diff. Render as a **side-by-side before/after pair** by default (see §5 "Showing change"); use a **single annotated "after" diagram** only when the change is purely additive and touches ≤ 3 elements. Explicitly skip diagrams that would be a single node, two nodes with one arrow, or a literal restatement of the diff.
 
 **Announce the plan in chat** before creating anything, e.g.:
 
@@ -217,6 +243,8 @@ Use a **horizontal row layout** because tables and docs have fixed width but var
 | Medium | 6–15 | < 500 | 1–2 (summary + deep-dive if needed) | 1–3 |
 | Large | 16–30 | < 1500 | 2–3 (summary + architecture + security if applicable) | 2–4 |
 | Very Large | 30+ | ≥ 1500 | 3+ (by subsystem) | 3+ |
+
+> A side-by-side before/after pair counts as **one** diagram for the budgets above — the column limits conceptual artifacts, not raw board widgets.
 
 ---
 
@@ -357,37 +385,80 @@ For Very Large PRs, create per-subsystem documents (continue incrementing x by 8
 
 Create diagrams based on the type of changes. Position after the last document (continue x increments of 800).
 
+##### Showing change: before/after vs. annotated
+
+Every diagram must make the *delta* visible at a glance, not just the post-change state.
+
+- **Default: side-by-side before/after pair.** Build two diagrams of the same type with the same DSL conventions and place them adjacently on the same y-row. Build the "before" from the `LINK_BASE_SHA` revision (use `git show $LINK_BASE_SHA:path` when the unified diff doesn't carry enough surrounding structure), and the "after" from `LINK_SHA`.
+- **Single annotated "after" diagram instead** when *all* of these hold:
+  - The change is purely additive (no deleted files, no removed classes/components, no removed edges in the relevant subsystem), AND
+  - The additions do not rearrange existing relationships (no rewired callers, no moved responsibilities), AND
+  - There are ≤ 3 new nodes/edges to mark.
+- If `LINK_BASE_SHA` is unreachable (shallow clone, history pruned), degrade every pair to a single annotated "after" diagram and reuse the chat announcement from §2.
+
+##### Marking convention
+
+Primary signal is the **label prefix**, because per-element styling is not guaranteed by the Miro Mermaid renderer:
+
+- `[ADDED] <name>` — element introduced in this change. In an *after* diagram only (omitted from before).
+- `[REMOVED] <name>` — element deleted in this change. In a *before* diagram only (omitted from after).
+- `[MOD] <name>` — element kept but with a meaningful change to signature, body, or relationships. Present in both diagrams; prefix appears in the *after* only.
+- Unmarked elements are unchanged context.
+
+Also emit Mermaid `classDef` directives as a best-effort visual layer — a renderer that honours them produces colour:
+
+```mermaid
+classDef added    fill:#dcfce7,stroke:#16a34a,stroke-width:2px;
+classDef removed  fill:#fee2e2,stroke:#dc2626,stroke-width:2px,stroke-dasharray:5 5;
+classDef modified fill:#fef3c7,stroke:#d97706,stroke-width:2px;
+class A,B added
+class C removed
+class D modified
+```
+
+Prefixes alone must be self-sufficient: if Miro drops the classDef block, the reviewer still sees what changed from the label text.
+
+##### Legend
+
+After the first diagram (or pair) on the board, place a small text/sticky:
+
+> Legend: `[ADDED]` new in this change · `[REMOVED]` deleted · `[MOD]` modified · unmarked = unchanged context
+
+One legend per code-review board is enough.
+
 **Diagram Selection Guide:**
 
-| Change Type | Diagram Type | Purpose |
-|-------------|--------------|---------|
-| Feature addition | `flowchart` | Show component interactions |
-| Refactoring | `uml_class` | Show structural changes |
-| API/integration | `uml_sequence` | Show interaction flow |
-| Database changes | `entity_relationship` | Show schema modifications |
-| Bug fix | `flowchart` | Show fix location in flow |
-| Data pipeline | `flowchart` | Show data flow |
+| Change Type | Diagram Type | Pattern | Purpose |
+|-------------|--------------|---------|---------|
+| Feature addition (purely additive) | `flowchart` | Single annotated (after) | Show new components and how they wire in |
+| Refactoring | `uml_class` | Side-by-side before/after | Structural rearrangement is the whole point |
+| API/integration change | `uml_sequence` | Side-by-side before/after | Flow shape changes |
+| DB migration / schema change | `entity_relationship` | Side-by-side before/after | Schema delta is the focus |
+| Bug fix | `flowchart` | Single annotated (after) | Mark the fix point in the flow |
+| Data pipeline restructure | `flowchart` | Side-by-side before/after | Data flow shape changes |
+| Mixed / large refactor | per-subsystem | Side-by-side per subsystem | One pair per affected boundary |
 
 **Diagram Positions:**
 
-Position diagrams after the last document. For a typical Large PR with 3 docs:
+A side-by-side pair occupies two adjacent x slots (gap = 2000 between pair members); the next diagram or pair starts another 2000 after the last slot used. A single annotated diagram occupies one slot. Let `N` = last document `x` + 800.
 
-| Diagram | Position | When to Create |
-|---------|----------|----------------|
-| Main flow/architecture | x=3200, y=0 | Always |
-| Component relationships | x=4000, y=0 | Medium+ PRs |
-| Sequence/interaction | x=4800, y=0 | API changes |
-| Data flow | x=5600, y=0 | Data pipeline changes |
-| Before/after comparison | x=6400, y=0 | Major refactoring |
+| Diagram (or pair) | Position(s) | When to create |
+|-------------------|-------------|----------------|
+| Main flow/architecture pair | `before` at x=N, `after` at x=N+2000 | Always |
+| Component relationships pair | next two slots | Medium+ PRs with structural change |
+| Sequence/interaction pair | next two slots | API/integration changes |
+| ER pair | next two slots | Data pipeline / schema changes |
+| Single annotated (additions only) | one slot | Purely additive change, ≤ 3 new elements |
 
-Adjust starting x based on actual number of documents created.
+Adjust `N` based on the actual number of documents created.
 
 **Each diagram should show:**
 - Affected components/modules (highlighted)
 - Data/control flow through changed code
 - Dependencies between changed files
 - Trust boundaries (for security-relevant changes)
-- Where a node corresponds to a single source file, append its URL on a second line of the label so a reader can copy it (paths only — diagram nodes are not clickable). Skip the URL when no remote is available.
+- Where a node corresponds to a single source file, append its URL on a second line of the label so a reader can copy it (paths only — diagram nodes are not clickable). Skip the URL when no remote is available. Use `LINK_BASE_SHA` in URLs on *before* diagrams; use `LINK_SHA` on *after* diagrams.
+- The change markers from §5 "Marking convention" applied to every modified/added/removed element — the diagram or pair must make the delta visible at a glance.
 
 ### 6. Post link back to PR/MR
 
@@ -456,7 +527,7 @@ If the §4.5 bail-out applied, the entire output is the trivial-PR chat message 
 Otherwise, after completion provide:
 1. Link to the Miro board (or frame, if `moveToWidget` was provided)
 2. Confirmation that the PR/MR description was updated, or that we left a comment as a fallback, or that the post step was skipped because the source was local / branchless
-3. Summary of elements created (X docs, Y diagrams, Z table rows) — and which artifact types were intentionally skipped per §4.5, with a one-line reason
+3. Summary of elements created (X docs, Y diagrams as N pairs + M single annotated, Z table rows) — base revision `<short LINK_BASE_SHA>`, head revision `<short LINK_SHA>` — and which artifact types were intentionally skipped per §4.5, with a one-line reason
 4. High-risk files requiring careful review
 5. Security findings (if any critical/high)
 6. Architecture concerns (if any breaking changes)

--- a/claude-plugins/miro/skills/miro-code-review/SKILL.md
+++ b/claude-plugins/miro/skills/miro-code-review/SKILL.md
@@ -402,7 +402,7 @@ Primary signal is the **label prefix**, because per-element styling is not guara
 
 - `[ADDED] <name>` — element introduced in this change. In an *after* diagram only (omitted from before).
 - `[REMOVED] <name>` — element deleted in this change. In a *before* diagram only (omitted from after).
-- `[MOD] <name>` — element kept but with a meaningful change to signature, body, or relationships. Present in both diagrams; prefix appears in the *after* only.
+- `[UPDATED] <name>` — element kept but with a meaningful change to signature, body, or relationships. Present in both diagrams; prefix appears in the *after* only.
 - Unmarked elements are unchanged context.
 
 Also emit Mermaid `classDef` directives as a best-effort visual layer — a renderer that honours them produces colour:
@@ -410,21 +410,13 @@ Also emit Mermaid `classDef` directives as a best-effort visual layer — a rend
 ```mermaid
 classDef added    fill:#dcfce7,stroke:#16a34a,stroke-width:2px;
 classDef removed  fill:#fee2e2,stroke:#dc2626,stroke-width:2px,stroke-dasharray:5 5;
-classDef modified fill:#fef3c7,stroke:#d97706,stroke-width:2px;
+classDef updated  fill:#fef3c7,stroke:#d97706,stroke-width:2px;
 class A,B added
 class C removed
-class D modified
+class D updated
 ```
 
 Prefixes alone must be self-sufficient: if Miro drops the classDef block, the reviewer still sees what changed from the label text.
-
-##### Legend
-
-After the first diagram (or pair) on the board, place a small text/sticky:
-
-> Legend: `[ADDED]` new in this change · `[REMOVED]` deleted · `[MOD]` modified · unmarked = unchanged context
-
-One legend per code-review board is enough.
 
 **Diagram Selection Guide:**
 
@@ -527,7 +519,7 @@ If the §4.5 bail-out applied, the entire output is the trivial-PR chat message 
 Otherwise, after completion provide:
 1. Link to the Miro board (or frame, if `moveToWidget` was provided)
 2. Confirmation that the PR/MR description was updated, or that we left a comment as a fallback, or that the post step was skipped because the source was local / branchless
-3. Summary of elements created (X docs, Y diagrams as N pairs + M single annotated, Z table rows) — base revision `<short LINK_BASE_SHA>`, head revision `<short LINK_SHA>` — and which artifact types were intentionally skipped per §4.5, with a one-line reason
+3. Summary of elements created (X docs, Y diagrams as N pairs + M single annotated, Z table rows). Mention base revision `<short LINK_BASE_SHA>` and head revision `<short LINK_SHA>` in this chat summary only — do **not** place these SHAs on the Miro board. Also note which artifact types were intentionally skipped per §4.5, with a one-line reason.
 4. High-risk files requiring careful review
 5. Security findings (if any critical/high)
 6. Architecture concerns (if any breaking changes)

--- a/claude-plugins/miro/skills/miro-code-review/SKILL.md
+++ b/claude-plugins/miro/skills/miro-code-review/SKILL.md
@@ -78,6 +78,40 @@ git log $DEFAULT_BRANCH..HEAD --oneline
 git diff $DEFAULT_BRANCH...HEAD
 ```
 
+#### Determine the source-link base URL
+
+Capture once and reuse for every file reference in §5 (table cells, document bullets, diagram labels). Pin links to the head SHA so they survive force-pushes.
+
+Record:
+
+- `LINK_HOST` — host from §1 (e.g. `github.com`, `gitlab.com`, self-hosted)
+- `LINK_OWNER` / `LINK_REPO` (GitHub-style) **or** `LINK_GROUP` / `LINK_PROJECT` (GitLab-style)
+- `LINK_SHA` — PR/MR head commit SHA, fetched per platform:
+
+```bash
+# GitHub
+LINK_SHA=$(gh pr view $PR_NUMBER --json headRefOid -q .headRefOid)
+# external repo: add --repo $OWNER/$REPO
+
+# GitLab
+LINK_SHA=$(glab mr view $MR_NUMBER -F json | jq -r '.diff_refs.head_sha // .sha')
+# external project: add -R $GROUP/$PROJECT
+
+# Local diff or branch comparison
+LINK_SHA=$(git rev-parse HEAD)
+```
+
+REST fallback: read `head.sha` (GitHub) or `diff_refs.head_sha` (GitLab) from the same JSON payload already fetched above — no extra round-trip needed.
+
+- `LINK_TEMPLATE` — pick by host shape; substitute `{path}` per reference, append `#L<start>-L<end>` line anchors when calling out a specific hunk:
+  - GitHub-style: `https://{host}/{owner}/{repo}/blob/{sha}/{path}` (anchor: `#L{a}-L{b}`)
+  - GitLab-style: `https://{host}/{group}/{project}/-/blob/{sha}/{path}` (anchor: `#L{a}-{b}`)
+  - Bitbucket-style (example pattern, not exhaustive): `https://{host}/{workspace}/{repo}/src/{sha}/{path}`
+
+**No-remote sources** (`local changes`, or a branch with no pushed remote / no PR): set `LINK_TEMPLATE=""` and announce in chat once: `"No remote URL available — file references shown as plain paths."` Do not invent URLs.
+
+State the chosen template in chat before creating artifacts, e.g.: `Source links: https://github.com/acme/api/blob/<sha>/{path}`.
+
 ### 3. Analyze Changes
 
 For each changed file, determine:
@@ -110,9 +144,55 @@ For each changed file, determine:
 | **Medium** | API changes, configuration, shared utilities, new dependencies, data model changes |
 | **Low** | Tests, documentation, styling, localization, internal refactoring |
 
+### 4.5 Triage: decide what (if anything) to create
+
+Every artifact must earn its place. Before doing any creation work, decide whether the PR is worth visualizing at all and which artifact types would actually help a reviewer.
+
+**Bail-out rule.** If **all** of the following hold, create no Miro artifacts and report only in chat:
+
+- ≤ 2 files changed, AND
+- < 20 lines changed (additions + deletions combined), AND
+- No file marked **High** risk in §4, AND
+- No security-sensitive paths touched (auth, crypto, config, migrations).
+
+In that case, the entire skill output is a single chat message of the form:
+
+> PR is trivial (N files, ±M lines, no high-risk areas). Skipping Miro visualization — a board would not add review value. PR/MR description was not modified.
+
+Skip §5 and §6 entirely.
+
+**Value gate (per artifact).** When the bail-out does not apply, still only create an artifact if it tells a reviewer something the diff itself does not already make obvious:
+
+- **Table** — create when ≥ 3 files changed *or* mixed risk levels exist. For 1–2 file PRs that don't bail out, skip the table.
+- **Summary doc** — create when the PR has non-trivial intent that isn't already captured in the PR title/body, OR when ≥ 2 high-risk items need callouts. Skip if it would just paraphrase the PR description.
+- **Architecture doc** — create only if structural changes are detected (new modules, modified public interfaces, dependency changes, breaking changes). Skip otherwise.
+- **Security doc** — create only when security-sensitive paths are touched (see §3 "Security Analysis"). Never create as a checklist-only artifact.
+- **Diagram** — create only when the change involves multi-component flow, control/data path changes, or structural relationships that are hard to grasp from the diff. Explicitly skip diagrams that would be a single node, two nodes with one arrow, or a literal restatement of the diff.
+
+**Announce the plan in chat** before creating anything, e.g.:
+
+> Plan: 1 table, 1 summary doc, no diagrams (changes are localized to a single function).
+
+This makes the triage visible and lets the user redirect before any board content is created.
+
 ### 5. Create Miro Board Content
 
-**IMPORTANT: Scale content based on PR size.** Create multiple documents and diagrams for larger PRs.
+**Principle:** every artifact must earn its place. If an artifact would not help a reviewer understand the PR faster than the diff alone, do not create it. See §4.5 for the triage rules.
+
+**Scale content *up to* these caps based on PR size, and apply the §4.5 value gates — fewer artifacts is fine.**
+
+#### Linking conventions
+
+Every file reference produced in §5 must be a clickable hyperlink to the source platform when a base URL is available. Use the `LINK_TEMPLATE` and `LINK_SHA` captured in §2.
+
+- **When `LINK_TEMPLATE` is set** (PR/MR or branch with a known remote): build the URL by substituting the file `{path}`. Add a line anchor `#L<start>-L<end>` when calling out a specific hunk (high-risk files, security findings, architecture callouts). Resolve start/end from the diff hunks captured in §2 (`@@ -a,b +c,d @@`, use the new-file range). Skip the anchor if the reference spans multiple non-contiguous hunks.
+- **When `LINK_TEMPLATE` is empty** (`local changes` or no remote): render every file reference as a plain path. Do not invent URLs.
+
+Per-artifact rules:
+
+- **Table → File column**: put the full URL as the cell content. Miro renders URLs in text cells as clickable links. With no remote, put the plain path.
+- **Documents**: use markdown links — `[path/to/file.ts](url)` for whole-file references and `[path/to/file.ts:42-58](url#L42-L58)` for hunk references. Apply this in *every* file mention (Overview, Key Changes, High-Risk Areas, Architecture > New Components / Modified Interfaces, Security > Security-Sensitive Changes, etc.).
+- **Diagrams**: keep node labels as plain paths — the Miro diagram tool does not document clickable nodes. When a node corresponds to a single source file, append the URL as a second line in the node label so a reader can copy it.
 
 **Positioning Notes:**
 
@@ -130,12 +210,13 @@ Use a **horizontal row layout** because tables and docs have fixed width but var
 
 #### Scaling Guidelines
 
-| PR Size | Files | Documents | Diagrams |
-|---------|-------|-----------|----------|
-| Small | 1-5 | 1 summary | 1 flow diagram |
-| Medium | 6-15 | 2 docs (summary + deep-dive) | 2-3 diagrams |
-| Large | 16-30 | 3 docs (summary + architecture + security) | 3-4 diagrams |
-| Very Large | 30+ | 4+ docs (by subsystem/area) | 5+ diagrams |
+| PR Size | Files | LOC (±) | Documents | Diagrams |
+|---------|-------|---------|-----------|----------|
+| Trivial | 1–2 | < 20 | none (bail out per §4.5) | none |
+| Small | 1–5 | < 100 | 0–1 summary | 0–1 flow |
+| Medium | 6–15 | < 500 | 1–2 (summary + deep-dive if needed) | 1–3 |
+| Large | 16–30 | < 1500 | 2–3 (summary + architecture + security if applicable) | 2–4 |
+| Very Large | 30+ | ≥ 1500 | 3+ (by subsystem) | 3+ |
 
 ---
 
@@ -146,7 +227,7 @@ Create first (appears at board center). Use Miro MCP tool to create a table with
 | Column | Type | Options |
 |--------|------|---------|
 | Status | select | Added (#00FF00), Modified (#FFA500), Deleted (#FF0000) |
-| File | text | File path |
+| File | text | Linked file URL (Miro auto-renders URLs in text cells as clickable). Use the plain path when no remote URL is available — see §5 "Linking conventions". |
 | Change | text | Brief summary of changes and key review points |
 | Risk | select | Low (#00FF00), Medium (#FFA500), High (#FF0000) |
 
@@ -160,7 +241,7 @@ For very large PRs (30+ files), create separate tables:
 
 **Document 1: Main Summary (x=800, y=0)**
 
-Always create this document:
+Create when the §4.5 value gate for the summary doc passes. Skip if the PR description already covers the same ground.
 
 ```markdown
 # Code Review: [PR Title]
@@ -178,7 +259,7 @@ Always create this document:
 - [Bullet points of significant changes]
 
 ## High-Risk Areas
-- [Files/components requiring careful review]
+- [path/to/file.ts:42-58](url#L42-L58) — [reason this file is high-risk]
 
 ## Review Checklist
 - [ ] Logic correctness verified
@@ -193,7 +274,7 @@ Always create this document:
 
 **Document 2: Architecture Analysis (x=1600, y=0)**
 
-Create for Medium+ PRs or when structural changes detected:
+Create only when the §4.5 architecture-doc value gate passes — i.e. the diff introduces new modules, modifies public interfaces, changes dependencies, or adds breaking changes. Skip otherwise, even on Medium/Large PRs.
 
 ```markdown
 # Architecture Analysis
@@ -201,13 +282,13 @@ Create for Medium+ PRs or when structural changes detected:
 ## Structural Changes
 
 ### New Components
-- [List new modules, services, classes]
+- [path/to/new_module.ts](url) — [purpose / role]
 
 ### Modified Interfaces
-- [API changes, contract modifications]
+- [path/to/api.ts:120-180](url#L120-L180) — [API change / contract modification]
 
 ### Dependency Changes
-- [New, removed, or updated dependencies]
+- [package.json](url) — [added/removed/updated dependency]
 
 ## Design Patterns
 - [Patterns introduced or modified]
@@ -225,7 +306,7 @@ Create for Medium+ PRs or when structural changes detected:
 
 **Document 3: Security Analysis (x=2400, y=0)**
 
-Create for Large+ PRs or when security-sensitive code detected:
+Create only when security-sensitive paths are touched (auth, crypto, config, migrations, input handling). Never create as a checklist-only artifact on a PR with no security-relevant diff.
 
 ```markdown
 # Security Analysis
@@ -233,9 +314,9 @@ Create for Large+ PRs or when security-sensitive code detected:
 **Risk Score:** [Critical/High/Medium/Low]
 
 ## Security-Sensitive Changes
-- [Auth/authz modifications]
-- [Data handling changes]
-- [API exposure changes]
+- [path/to/auth.ts:30-95](url#L30-L95) — [auth/authz modification]
+- [path/to/handler.ts:10-40](url#L10-L40) — [data handling change]
+- [path/to/route.ts:200-220](url#L200-L220) — [API exposure change]
 
 ## Vulnerability Assessment
 
@@ -306,6 +387,7 @@ Adjust starting x based on actual number of documents created.
 - Data/control flow through changed code
 - Dependencies between changed files
 - Trust boundaries (for security-relevant changes)
+- Where a node corresponds to a single source file, append its URL on a second line of the label so a reader can copy it (paths only — diagram nodes are not clickable). Skip the URL when no remote is available.
 
 ### 6. Post link back to PR/MR
 
@@ -369,10 +451,12 @@ If editing the description fails because the user lacks permission (for example,
 
 ## Output
 
-After completion, provide:
+If the §4.5 bail-out applied, the entire output is the trivial-PR chat message — no board link, no description update, nothing else.
+
+Otherwise, after completion provide:
 1. Link to the Miro board (or frame, if `moveToWidget` was provided)
 2. Confirmation that the PR/MR description was updated, or that we left a comment as a fallback, or that the post step was skipped because the source was local / branchless
-3. Summary of elements created (X docs, Y diagrams, Z table rows)
+3. Summary of elements created (X docs, Y diagrams, Z table rows) — and which artifact types were intentionally skipped per §4.5, with a one-line reason
 4. High-risk files requiring careful review
 5. Security findings (if any critical/high)
 6. Architecture concerns (if any breaking changes)

--- a/codex-plugins/miro/.codex-plugin/plugin.json
+++ b/codex-plugins/miro/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "miro",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Secure access to Miro boards. Enables AI to read board context, create diagrams, and generate code with enterprise-grade security.",
   "author": {
     "name": "Miro",

--- a/codex-plugins/miro/.codex-plugin/plugin.json
+++ b/codex-plugins/miro/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "miro",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Secure access to Miro boards. Enables AI to read board context, create diagrams, and generate code with enterprise-grade security.",
   "author": {
     "name": "Miro",

--- a/codex-plugins/miro/.codex-plugin/plugin.json
+++ b/codex-plugins/miro/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "miro",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "description": "Secure access to Miro boards. Enables AI to read board context, create diagrams, and generate code with enterprise-grade security.",
   "author": {
     "name": "Miro",

--- a/codex-plugins/miro/skills/miro-code-review/SKILL.md
+++ b/codex-plugins/miro/skills/miro-code-review/SKILL.md
@@ -103,6 +103,32 @@ LINK_SHA=$(git rev-parse HEAD)
 
 REST fallback: read `head.sha` (GitHub) or `diff_refs.head_sha` (GitLab) from the same JSON payload already fetched above — no extra round-trip needed.
 
+- `LINK_BASE_SHA` — base commit SHA (the PR/MR target tip, or the merge-base for branch comparisons). Required by §5 "Showing change" to render before/after diagrams and to hyperlink "before" nodes to the prior revision:
+
+```bash
+# GitHub
+LINK_BASE_SHA=$(gh pr view $PR_NUMBER --json baseRefOid -q .baseRefOid)
+# external repo: add --repo $OWNER/$REPO
+
+# GitLab
+LINK_BASE_SHA=$(glab mr view $MR_NUMBER -F json | jq -r '.diff_refs.base_sha // .target_branch')
+# external project: add -R $GROUP/$PROJECT
+
+# Local diff (uncommitted): base is the current HEAD itself
+LINK_BASE_SHA=$(git rev-parse HEAD)
+
+# Branch comparison
+LINK_BASE_SHA=$(git merge-base origin/$DEFAULT_BRANCH HEAD)
+```
+
+To extract the pre-change content of a single file (needed when the unified diff alone doesn't carry enough surrounding structure, e.g. class hierarchies):
+
+```bash
+git show $LINK_BASE_SHA:path/to/file
+```
+
+If the base SHA is unreachable (shallow clone, history pruned, target branch not fetched), skip "before" diagrams and announce once in chat: `"base revision unavailable — only 'after' diagrams created"`.
+
 - `LINK_TEMPLATE` — pick by host shape; substitute `{path}` per reference, append `#L<start>-L<end>` line anchors when calling out a specific hunk:
   - GitHub-style: `https://{host}/{owner}/{repo}/blob/{sha}/{path}` (anchor: `#L{a}-L{b}`)
   - GitLab-style: `https://{host}/{group}/{project}/-/blob/{sha}/{path}` (anchor: `#L{a}-{b}`)
@@ -167,7 +193,7 @@ Skip §5 and §6 entirely.
 - **Summary doc** — create when the PR has non-trivial intent that isn't already captured in the PR title/body, OR when ≥ 2 high-risk items need callouts. Skip if it would just paraphrase the PR description.
 - **Architecture doc** — create only if structural changes are detected (new modules, modified public interfaces, dependency changes, breaking changes). Skip otherwise.
 - **Security doc** — create only when security-sensitive paths are touched (see §3 "Security Analysis"). Never create as a checklist-only artifact.
-- **Diagram** — create only when the change involves multi-component flow, control/data path changes, or structural relationships that are hard to grasp from the diff. Explicitly skip diagrams that would be a single node, two nodes with one arrow, or a literal restatement of the diff.
+- **Diagram** — create only when the change involves multi-component flow, control/data path changes, or structural relationships that are hard to grasp from the diff. Render as a **side-by-side before/after pair** by default (see §5 "Showing change"); use a **single annotated "after" diagram** only when the change is purely additive and touches ≤ 3 elements. Explicitly skip diagrams that would be a single node, two nodes with one arrow, or a literal restatement of the diff.
 
 **Announce the plan in chat** before creating anything, e.g.:
 
@@ -217,6 +243,8 @@ Use a **horizontal row layout** because tables and docs have fixed width but var
 | Medium | 6–15 | < 500 | 1–2 (summary + deep-dive if needed) | 1–3 |
 | Large | 16–30 | < 1500 | 2–3 (summary + architecture + security if applicable) | 2–4 |
 | Very Large | 30+ | ≥ 1500 | 3+ (by subsystem) | 3+ |
+
+> A side-by-side before/after pair counts as **one** diagram for the budgets above — the column limits conceptual artifacts, not raw board widgets.
 
 ---
 
@@ -357,37 +385,80 @@ For Very Large PRs, create per-subsystem documents (continue incrementing x by 8
 
 Create diagrams based on the type of changes. Position after the last document (continue x increments of 800).
 
+##### Showing change: before/after vs. annotated
+
+Every diagram must make the *delta* visible at a glance, not just the post-change state.
+
+- **Default: side-by-side before/after pair.** Build two diagrams of the same type with the same DSL conventions and place them adjacently on the same y-row. Build the "before" from the `LINK_BASE_SHA` revision (use `git show $LINK_BASE_SHA:path` when the unified diff doesn't carry enough surrounding structure), and the "after" from `LINK_SHA`.
+- **Single annotated "after" diagram instead** when *all* of these hold:
+  - The change is purely additive (no deleted files, no removed classes/components, no removed edges in the relevant subsystem), AND
+  - The additions do not rearrange existing relationships (no rewired callers, no moved responsibilities), AND
+  - There are ≤ 3 new nodes/edges to mark.
+- If `LINK_BASE_SHA` is unreachable (shallow clone, history pruned), degrade every pair to a single annotated "after" diagram and reuse the chat announcement from §2.
+
+##### Marking convention
+
+Primary signal is the **label prefix**, because per-element styling is not guaranteed by the Miro Mermaid renderer:
+
+- `[ADDED] <name>` — element introduced in this change. In an *after* diagram only (omitted from before).
+- `[REMOVED] <name>` — element deleted in this change. In a *before* diagram only (omitted from after).
+- `[MOD] <name>` — element kept but with a meaningful change to signature, body, or relationships. Present in both diagrams; prefix appears in the *after* only.
+- Unmarked elements are unchanged context.
+
+Also emit Mermaid `classDef` directives as a best-effort visual layer — a renderer that honours them produces colour:
+
+```mermaid
+classDef added    fill:#dcfce7,stroke:#16a34a,stroke-width:2px;
+classDef removed  fill:#fee2e2,stroke:#dc2626,stroke-width:2px,stroke-dasharray:5 5;
+classDef modified fill:#fef3c7,stroke:#d97706,stroke-width:2px;
+class A,B added
+class C removed
+class D modified
+```
+
+Prefixes alone must be self-sufficient: if Miro drops the classDef block, the reviewer still sees what changed from the label text.
+
+##### Legend
+
+After the first diagram (or pair) on the board, place a small text/sticky:
+
+> Legend: `[ADDED]` new in this change · `[REMOVED]` deleted · `[MOD]` modified · unmarked = unchanged context
+
+One legend per code-review board is enough.
+
 **Diagram Selection Guide:**
 
-| Change Type | Diagram Type | Purpose |
-|-------------|--------------|---------|
-| Feature addition | `flowchart` | Show component interactions |
-| Refactoring | `uml_class` | Show structural changes |
-| API/integration | `uml_sequence` | Show interaction flow |
-| Database changes | `entity_relationship` | Show schema modifications |
-| Bug fix | `flowchart` | Show fix location in flow |
-| Data pipeline | `flowchart` | Show data flow |
+| Change Type | Diagram Type | Pattern | Purpose |
+|-------------|--------------|---------|---------|
+| Feature addition (purely additive) | `flowchart` | Single annotated (after) | Show new components and how they wire in |
+| Refactoring | `uml_class` | Side-by-side before/after | Structural rearrangement is the whole point |
+| API/integration change | `uml_sequence` | Side-by-side before/after | Flow shape changes |
+| DB migration / schema change | `entity_relationship` | Side-by-side before/after | Schema delta is the focus |
+| Bug fix | `flowchart` | Single annotated (after) | Mark the fix point in the flow |
+| Data pipeline restructure | `flowchart` | Side-by-side before/after | Data flow shape changes |
+| Mixed / large refactor | per-subsystem | Side-by-side per subsystem | One pair per affected boundary |
 
 **Diagram Positions:**
 
-Position diagrams after the last document. For a typical Large PR with 3 docs:
+A side-by-side pair occupies two adjacent x slots (gap = 2000 between pair members); the next diagram or pair starts another 2000 after the last slot used. A single annotated diagram occupies one slot. Let `N` = last document `x` + 800.
 
-| Diagram | Position | When to Create |
-|---------|----------|----------------|
-| Main flow/architecture | x=3200, y=0 | Always |
-| Component relationships | x=4000, y=0 | Medium+ PRs |
-| Sequence/interaction | x=4800, y=0 | API changes |
-| Data flow | x=5600, y=0 | Data pipeline changes |
-| Before/after comparison | x=6400, y=0 | Major refactoring |
+| Diagram (or pair) | Position(s) | When to create |
+|-------------------|-------------|----------------|
+| Main flow/architecture pair | `before` at x=N, `after` at x=N+2000 | Always |
+| Component relationships pair | next two slots | Medium+ PRs with structural change |
+| Sequence/interaction pair | next two slots | API/integration changes |
+| ER pair | next two slots | Data pipeline / schema changes |
+| Single annotated (additions only) | one slot | Purely additive change, ≤ 3 new elements |
 
-Adjust starting x based on actual number of documents created.
+Adjust `N` based on the actual number of documents created.
 
 **Each diagram should show:**
 - Affected components/modules (highlighted)
 - Data/control flow through changed code
 - Dependencies between changed files
 - Trust boundaries (for security-relevant changes)
-- Where a node corresponds to a single source file, append its URL on a second line of the label so a reader can copy it (paths only — diagram nodes are not clickable). Skip the URL when no remote is available.
+- Where a node corresponds to a single source file, append its URL on a second line of the label so a reader can copy it (paths only — diagram nodes are not clickable). Skip the URL when no remote is available. Use `LINK_BASE_SHA` in URLs on *before* diagrams; use `LINK_SHA` on *after* diagrams.
+- The change markers from §5 "Marking convention" applied to every modified/added/removed element — the diagram or pair must make the delta visible at a glance.
 
 ### 6. Post link back to PR/MR
 
@@ -456,7 +527,7 @@ If the §4.5 bail-out applied, the entire output is the trivial-PR chat message 
 Otherwise, after completion provide:
 1. Link to the Miro board (or frame, if `moveToWidget` was provided)
 2. Confirmation that the PR/MR description was updated, or that we left a comment as a fallback, or that the post step was skipped because the source was local / branchless
-3. Summary of elements created (X docs, Y diagrams, Z table rows) — and which artifact types were intentionally skipped per §4.5, with a one-line reason
+3. Summary of elements created (X docs, Y diagrams as N pairs + M single annotated, Z table rows) — base revision `<short LINK_BASE_SHA>`, head revision `<short LINK_SHA>` — and which artifact types were intentionally skipped per §4.5, with a one-line reason
 4. High-risk files requiring careful review
 5. Security findings (if any critical/high)
 6. Architecture concerns (if any breaking changes)

--- a/codex-plugins/miro/skills/miro-code-review/SKILL.md
+++ b/codex-plugins/miro/skills/miro-code-review/SKILL.md
@@ -402,7 +402,7 @@ Primary signal is the **label prefix**, because per-element styling is not guara
 
 - `[ADDED] <name>` — element introduced in this change. In an *after* diagram only (omitted from before).
 - `[REMOVED] <name>` — element deleted in this change. In a *before* diagram only (omitted from after).
-- `[MOD] <name>` — element kept but with a meaningful change to signature, body, or relationships. Present in both diagrams; prefix appears in the *after* only.
+- `[UPDATED] <name>` — element kept but with a meaningful change to signature, body, or relationships. Present in both diagrams; prefix appears in the *after* only.
 - Unmarked elements are unchanged context.
 
 Also emit Mermaid `classDef` directives as a best-effort visual layer — a renderer that honours them produces colour:
@@ -410,21 +410,13 @@ Also emit Mermaid `classDef` directives as a best-effort visual layer — a rend
 ```mermaid
 classDef added    fill:#dcfce7,stroke:#16a34a,stroke-width:2px;
 classDef removed  fill:#fee2e2,stroke:#dc2626,stroke-width:2px,stroke-dasharray:5 5;
-classDef modified fill:#fef3c7,stroke:#d97706,stroke-width:2px;
+classDef updated  fill:#fef3c7,stroke:#d97706,stroke-width:2px;
 class A,B added
 class C removed
-class D modified
+class D updated
 ```
 
-Prefixes alone must be self-sufficient: if Miro drops the classDef block, the reviewer still sees what changed from the label text.
-
-##### Legend
-
-After the first diagram (or pair) on the board, place a small text/sticky:
-
-> Legend: `[ADDED]` new in this change · `[REMOVED]` deleted · `[MOD]` modified · unmarked = unchanged context
-
-One legend per code-review board is enough.
+Prefixes alone must be self-sufficient: if Miro drops the classDef block, the reviewer still sees what changed from the label text. Do not create a legend widget on the board — the prefixes are self-explanatory and a separate legend just clutters the layout.
 
 **Diagram Selection Guide:**
 
@@ -527,7 +519,7 @@ If the §4.5 bail-out applied, the entire output is the trivial-PR chat message 
 Otherwise, after completion provide:
 1. Link to the Miro board (or frame, if `moveToWidget` was provided)
 2. Confirmation that the PR/MR description was updated, or that we left a comment as a fallback, or that the post step was skipped because the source was local / branchless
-3. Summary of elements created (X docs, Y diagrams as N pairs + M single annotated, Z table rows) — base revision `<short LINK_BASE_SHA>`, head revision `<short LINK_SHA>` — and which artifact types were intentionally skipped per §4.5, with a one-line reason
+3. Summary of elements created (X docs, Y diagrams as N pairs + M single annotated, Z table rows). Mention base revision `<short LINK_BASE_SHA>` and head revision `<short LINK_SHA>` in this chat summary only — do **not** place these SHAs on the Miro board. Also note which artifact types were intentionally skipped per §4.5, with a one-line reason.
 4. High-risk files requiring careful review
 5. Security findings (if any critical/high)
 6. Architecture concerns (if any breaking changes)

--- a/codex-plugins/miro/skills/miro-code-review/SKILL.md
+++ b/codex-plugins/miro/skills/miro-code-review/SKILL.md
@@ -78,6 +78,40 @@ git log $DEFAULT_BRANCH..HEAD --oneline
 git diff $DEFAULT_BRANCH...HEAD
 ```
 
+#### Determine the source-link base URL
+
+Capture once and reuse for every file reference in §5 (table cells, document bullets, diagram labels). Pin links to the head SHA so they survive force-pushes.
+
+Record:
+
+- `LINK_HOST` — host from §1 (e.g. `github.com`, `gitlab.com`, self-hosted)
+- `LINK_OWNER` / `LINK_REPO` (GitHub-style) **or** `LINK_GROUP` / `LINK_PROJECT` (GitLab-style)
+- `LINK_SHA` — PR/MR head commit SHA, fetched per platform:
+
+```bash
+# GitHub
+LINK_SHA=$(gh pr view $PR_NUMBER --json headRefOid -q .headRefOid)
+# external repo: add --repo $OWNER/$REPO
+
+# GitLab
+LINK_SHA=$(glab mr view $MR_NUMBER -F json | jq -r '.diff_refs.head_sha // .sha')
+# external project: add -R $GROUP/$PROJECT
+
+# Local diff or branch comparison
+LINK_SHA=$(git rev-parse HEAD)
+```
+
+REST fallback: read `head.sha` (GitHub) or `diff_refs.head_sha` (GitLab) from the same JSON payload already fetched above — no extra round-trip needed.
+
+- `LINK_TEMPLATE` — pick by host shape; substitute `{path}` per reference, append `#L<start>-L<end>` line anchors when calling out a specific hunk:
+  - GitHub-style: `https://{host}/{owner}/{repo}/blob/{sha}/{path}` (anchor: `#L{a}-L{b}`)
+  - GitLab-style: `https://{host}/{group}/{project}/-/blob/{sha}/{path}` (anchor: `#L{a}-{b}`)
+  - Bitbucket-style (example pattern, not exhaustive): `https://{host}/{workspace}/{repo}/src/{sha}/{path}`
+
+**No-remote sources** (`local changes`, or a branch with no pushed remote / no PR): set `LINK_TEMPLATE=""` and announce in chat once: `"No remote URL available — file references shown as plain paths."` Do not invent URLs.
+
+State the chosen template in chat before creating artifacts, e.g.: `Source links: https://github.com/acme/api/blob/<sha>/{path}`.
+
 ### 3. Analyze Changes
 
 For each changed file, determine:
@@ -110,9 +144,55 @@ For each changed file, determine:
 | **Medium** | API changes, configuration, shared utilities, new dependencies, data model changes |
 | **Low** | Tests, documentation, styling, localization, internal refactoring |
 
+### 4.5 Triage: decide what (if anything) to create
+
+Every artifact must earn its place. Before doing any creation work, decide whether the PR is worth visualizing at all and which artifact types would actually help a reviewer.
+
+**Bail-out rule.** If **all** of the following hold, create no Miro artifacts and report only in chat:
+
+- ≤ 2 files changed, AND
+- < 20 lines changed (additions + deletions combined), AND
+- No file marked **High** risk in §4, AND
+- No security-sensitive paths touched (auth, crypto, config, migrations).
+
+In that case, the entire skill output is a single chat message of the form:
+
+> PR is trivial (N files, ±M lines, no high-risk areas). Skipping Miro visualization — a board would not add review value. PR/MR description was not modified.
+
+Skip §5 and §6 entirely.
+
+**Value gate (per artifact).** When the bail-out does not apply, still only create an artifact if it tells a reviewer something the diff itself does not already make obvious:
+
+- **Table** — create when ≥ 3 files changed *or* mixed risk levels exist. For 1–2 file PRs that don't bail out, skip the table.
+- **Summary doc** — create when the PR has non-trivial intent that isn't already captured in the PR title/body, OR when ≥ 2 high-risk items need callouts. Skip if it would just paraphrase the PR description.
+- **Architecture doc** — create only if structural changes are detected (new modules, modified public interfaces, dependency changes, breaking changes). Skip otherwise.
+- **Security doc** — create only when security-sensitive paths are touched (see §3 "Security Analysis"). Never create as a checklist-only artifact.
+- **Diagram** — create only when the change involves multi-component flow, control/data path changes, or structural relationships that are hard to grasp from the diff. Explicitly skip diagrams that would be a single node, two nodes with one arrow, or a literal restatement of the diff.
+
+**Announce the plan in chat** before creating anything, e.g.:
+
+> Plan: 1 table, 1 summary doc, no diagrams (changes are localized to a single function).
+
+This makes the triage visible and lets the user redirect before any board content is created.
+
 ### 5. Create Miro Board Content
 
-**IMPORTANT: Scale content based on PR size.** Create multiple documents and diagrams for larger PRs.
+**Principle:** every artifact must earn its place. If an artifact would not help a reviewer understand the PR faster than the diff alone, do not create it. See §4.5 for the triage rules.
+
+**Scale content *up to* these caps based on PR size, and apply the §4.5 value gates — fewer artifacts is fine.**
+
+#### Linking conventions
+
+Every file reference produced in §5 must be a clickable hyperlink to the source platform when a base URL is available. Use the `LINK_TEMPLATE` and `LINK_SHA` captured in §2.
+
+- **When `LINK_TEMPLATE` is set** (PR/MR or branch with a known remote): build the URL by substituting the file `{path}`. Add a line anchor `#L<start>-L<end>` when calling out a specific hunk (high-risk files, security findings, architecture callouts). Resolve start/end from the diff hunks captured in §2 (`@@ -a,b +c,d @@`, use the new-file range). Skip the anchor if the reference spans multiple non-contiguous hunks.
+- **When `LINK_TEMPLATE` is empty** (`local changes` or no remote): render every file reference as a plain path. Do not invent URLs.
+
+Per-artifact rules:
+
+- **Table → File column**: put the full URL as the cell content. Miro renders URLs in text cells as clickable links. With no remote, put the plain path.
+- **Documents**: use markdown links — `[path/to/file.ts](url)` for whole-file references and `[path/to/file.ts:42-58](url#L42-L58)` for hunk references. Apply this in *every* file mention (Overview, Key Changes, High-Risk Areas, Architecture > New Components / Modified Interfaces, Security > Security-Sensitive Changes, etc.).
+- **Diagrams**: keep node labels as plain paths — the Miro diagram tool does not document clickable nodes. When a node corresponds to a single source file, append the URL as a second line in the node label so a reader can copy it.
 
 **Positioning Notes:**
 
@@ -130,12 +210,13 @@ Use a **horizontal row layout** because tables and docs have fixed width but var
 
 #### Scaling Guidelines
 
-| PR Size | Files | Documents | Diagrams |
-|---------|-------|-----------|----------|
-| Small | 1-5 | 1 summary | 1 flow diagram |
-| Medium | 6-15 | 2 docs (summary + deep-dive) | 2-3 diagrams |
-| Large | 16-30 | 3 docs (summary + architecture + security) | 3-4 diagrams |
-| Very Large | 30+ | 4+ docs (by subsystem/area) | 5+ diagrams |
+| PR Size | Files | LOC (±) | Documents | Diagrams |
+|---------|-------|---------|-----------|----------|
+| Trivial | 1–2 | < 20 | none (bail out per §4.5) | none |
+| Small | 1–5 | < 100 | 0–1 summary | 0–1 flow |
+| Medium | 6–15 | < 500 | 1–2 (summary + deep-dive if needed) | 1–3 |
+| Large | 16–30 | < 1500 | 2–3 (summary + architecture + security if applicable) | 2–4 |
+| Very Large | 30+ | ≥ 1500 | 3+ (by subsystem) | 3+ |
 
 ---
 
@@ -146,7 +227,7 @@ Create first (appears at board center). Use Miro MCP tool to create a table with
 | Column | Type | Options |
 |--------|------|---------|
 | Status | select | Added (#00FF00), Modified (#FFA500), Deleted (#FF0000) |
-| File | text | File path |
+| File | text | Linked file URL (Miro auto-renders URLs in text cells as clickable). Use the plain path when no remote URL is available — see §5 "Linking conventions". |
 | Change | text | Brief summary of changes and key review points |
 | Risk | select | Low (#00FF00), Medium (#FFA500), High (#FF0000) |
 
@@ -160,7 +241,7 @@ For very large PRs (30+ files), create separate tables:
 
 **Document 1: Main Summary (x=800, y=0)**
 
-Always create this document:
+Create when the §4.5 value gate for the summary doc passes. Skip if the PR description already covers the same ground.
 
 ```markdown
 # Code Review: [PR Title]
@@ -178,7 +259,7 @@ Always create this document:
 - [Bullet points of significant changes]
 
 ## High-Risk Areas
-- [Files/components requiring careful review]
+- [path/to/file.ts:42-58](url#L42-L58) — [reason this file is high-risk]
 
 ## Review Checklist
 - [ ] Logic correctness verified
@@ -193,7 +274,7 @@ Always create this document:
 
 **Document 2: Architecture Analysis (x=1600, y=0)**
 
-Create for Medium+ PRs or when structural changes detected:
+Create only when the §4.5 architecture-doc value gate passes — i.e. the diff introduces new modules, modifies public interfaces, changes dependencies, or adds breaking changes. Skip otherwise, even on Medium/Large PRs.
 
 ```markdown
 # Architecture Analysis
@@ -201,13 +282,13 @@ Create for Medium+ PRs or when structural changes detected:
 ## Structural Changes
 
 ### New Components
-- [List new modules, services, classes]
+- [path/to/new_module.ts](url) — [purpose / role]
 
 ### Modified Interfaces
-- [API changes, contract modifications]
+- [path/to/api.ts:120-180](url#L120-L180) — [API change / contract modification]
 
 ### Dependency Changes
-- [New, removed, or updated dependencies]
+- [package.json](url) — [added/removed/updated dependency]
 
 ## Design Patterns
 - [Patterns introduced or modified]
@@ -225,7 +306,7 @@ Create for Medium+ PRs or when structural changes detected:
 
 **Document 3: Security Analysis (x=2400, y=0)**
 
-Create for Large+ PRs or when security-sensitive code detected:
+Create only when security-sensitive paths are touched (auth, crypto, config, migrations, input handling). Never create as a checklist-only artifact on a PR with no security-relevant diff.
 
 ```markdown
 # Security Analysis
@@ -233,9 +314,9 @@ Create for Large+ PRs or when security-sensitive code detected:
 **Risk Score:** [Critical/High/Medium/Low]
 
 ## Security-Sensitive Changes
-- [Auth/authz modifications]
-- [Data handling changes]
-- [API exposure changes]
+- [path/to/auth.ts:30-95](url#L30-L95) — [auth/authz modification]
+- [path/to/handler.ts:10-40](url#L10-L40) — [data handling change]
+- [path/to/route.ts:200-220](url#L200-L220) — [API exposure change]
 
 ## Vulnerability Assessment
 
@@ -306,6 +387,7 @@ Adjust starting x based on actual number of documents created.
 - Data/control flow through changed code
 - Dependencies between changed files
 - Trust boundaries (for security-relevant changes)
+- Where a node corresponds to a single source file, append its URL on a second line of the label so a reader can copy it (paths only — diagram nodes are not clickable). Skip the URL when no remote is available.
 
 ### 6. Post link back to PR/MR
 
@@ -369,10 +451,12 @@ If editing the description fails because the user lacks permission (for example,
 
 ## Output
 
-After completion, provide:
+If the §4.5 bail-out applied, the entire output is the trivial-PR chat message — no board link, no description update, nothing else.
+
+Otherwise, after completion provide:
 1. Link to the Miro board (or frame, if `moveToWidget` was provided)
 2. Confirmation that the PR/MR description was updated, or that we left a comment as a fallback, or that the post step was skipped because the source was local / branchless
-3. Summary of elements created (X docs, Y diagrams, Z table rows)
+3. Summary of elements created (X docs, Y diagrams, Z table rows) — and which artifact types were intentionally skipped per §4.5, with a one-line reason
 4. High-risk files requiring careful review
 5. Security findings (if any critical/high)
 6. Architecture concerns (if any breaking changes)

--- a/copilot-cowork-plugins/miro/manifest.json
+++ b/copilot-cowork-plugins/miro/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.schema.json",
   "manifestVersion": "devPreview",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "id": "1b72f048-929d-554f-9995-9bc8e90f4c4f",
   "packageName": "com.cowork.plugin.miro",
   "developer": {

--- a/copilot-cowork-plugins/miro/manifest.json
+++ b/copilot-cowork-plugins/miro/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.schema.json",
   "manifestVersion": "devPreview",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "id": "1b72f048-929d-554f-9995-9bc8e90f4c4f",
   "packageName": "com.cowork.plugin.miro",
   "developer": {

--- a/copilot-cowork-plugins/miro/manifest.json
+++ b/copilot-cowork-plugins/miro/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.schema.json",
   "manifestVersion": "devPreview",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "id": "1b72f048-929d-554f-9995-9bc8e90f4c4f",
   "packageName": "com.cowork.plugin.miro",
   "developer": {

--- a/copilot-cowork-plugins/miro/skills/miro-code-review/SKILL.md
+++ b/copilot-cowork-plugins/miro/skills/miro-code-review/SKILL.md
@@ -103,6 +103,32 @@ LINK_SHA=$(git rev-parse HEAD)
 
 REST fallback: read `head.sha` (GitHub) or `diff_refs.head_sha` (GitLab) from the same JSON payload already fetched above — no extra round-trip needed.
 
+- `LINK_BASE_SHA` — base commit SHA (the PR/MR target tip, or the merge-base for branch comparisons). Required by §5 "Showing change" to render before/after diagrams and to hyperlink "before" nodes to the prior revision:
+
+```bash
+# GitHub
+LINK_BASE_SHA=$(gh pr view $PR_NUMBER --json baseRefOid -q .baseRefOid)
+# external repo: add --repo $OWNER/$REPO
+
+# GitLab
+LINK_BASE_SHA=$(glab mr view $MR_NUMBER -F json | jq -r '.diff_refs.base_sha // .target_branch')
+# external project: add -R $GROUP/$PROJECT
+
+# Local diff (uncommitted): base is the current HEAD itself
+LINK_BASE_SHA=$(git rev-parse HEAD)
+
+# Branch comparison
+LINK_BASE_SHA=$(git merge-base origin/$DEFAULT_BRANCH HEAD)
+```
+
+To extract the pre-change content of a single file (needed when the unified diff alone doesn't carry enough surrounding structure, e.g. class hierarchies):
+
+```bash
+git show $LINK_BASE_SHA:path/to/file
+```
+
+If the base SHA is unreachable (shallow clone, history pruned, target branch not fetched), skip "before" diagrams and announce once in chat: `"base revision unavailable — only 'after' diagrams created"`.
+
 - `LINK_TEMPLATE` — pick by host shape; substitute `{path}` per reference, append `#L<start>-L<end>` line anchors when calling out a specific hunk:
   - GitHub-style: `https://{host}/{owner}/{repo}/blob/{sha}/{path}` (anchor: `#L{a}-L{b}`)
   - GitLab-style: `https://{host}/{group}/{project}/-/blob/{sha}/{path}` (anchor: `#L{a}-{b}`)
@@ -167,7 +193,7 @@ Skip §5 and §6 entirely.
 - **Summary doc** — create when the PR has non-trivial intent that isn't already captured in the PR title/body, OR when ≥ 2 high-risk items need callouts. Skip if it would just paraphrase the PR description.
 - **Architecture doc** — create only if structural changes are detected (new modules, modified public interfaces, dependency changes, breaking changes). Skip otherwise.
 - **Security doc** — create only when security-sensitive paths are touched (see §3 "Security Analysis"). Never create as a checklist-only artifact.
-- **Diagram** — create only when the change involves multi-component flow, control/data path changes, or structural relationships that are hard to grasp from the diff. Explicitly skip diagrams that would be a single node, two nodes with one arrow, or a literal restatement of the diff.
+- **Diagram** — create only when the change involves multi-component flow, control/data path changes, or structural relationships that are hard to grasp from the diff. Render as a **side-by-side before/after pair** by default (see §5 "Showing change"); use a **single annotated "after" diagram** only when the change is purely additive and touches ≤ 3 elements. Explicitly skip diagrams that would be a single node, two nodes with one arrow, or a literal restatement of the diff.
 
 **Announce the plan in chat** before creating anything, e.g.:
 
@@ -217,6 +243,8 @@ Use a **horizontal row layout** because tables and docs have fixed width but var
 | Medium | 6–15 | < 500 | 1–2 (summary + deep-dive if needed) | 1–3 |
 | Large | 16–30 | < 1500 | 2–3 (summary + architecture + security if applicable) | 2–4 |
 | Very Large | 30+ | ≥ 1500 | 3+ (by subsystem) | 3+ |
+
+> A side-by-side before/after pair counts as **one** diagram for the budgets above — the column limits conceptual artifacts, not raw board widgets.
 
 ---
 
@@ -357,37 +385,80 @@ For Very Large PRs, create per-subsystem documents (continue incrementing x by 8
 
 Create diagrams based on the type of changes. Position after the last document (continue x increments of 800).
 
+##### Showing change: before/after vs. annotated
+
+Every diagram must make the *delta* visible at a glance, not just the post-change state.
+
+- **Default: side-by-side before/after pair.** Build two diagrams of the same type with the same DSL conventions and place them adjacently on the same y-row. Build the "before" from the `LINK_BASE_SHA` revision (use `git show $LINK_BASE_SHA:path` when the unified diff doesn't carry enough surrounding structure), and the "after" from `LINK_SHA`.
+- **Single annotated "after" diagram instead** when *all* of these hold:
+  - The change is purely additive (no deleted files, no removed classes/components, no removed edges in the relevant subsystem), AND
+  - The additions do not rearrange existing relationships (no rewired callers, no moved responsibilities), AND
+  - There are ≤ 3 new nodes/edges to mark.
+- If `LINK_BASE_SHA` is unreachable (shallow clone, history pruned), degrade every pair to a single annotated "after" diagram and reuse the chat announcement from §2.
+
+##### Marking convention
+
+Primary signal is the **label prefix**, because per-element styling is not guaranteed by the Miro Mermaid renderer:
+
+- `[ADDED] <name>` — element introduced in this change. In an *after* diagram only (omitted from before).
+- `[REMOVED] <name>` — element deleted in this change. In a *before* diagram only (omitted from after).
+- `[MOD] <name>` — element kept but with a meaningful change to signature, body, or relationships. Present in both diagrams; prefix appears in the *after* only.
+- Unmarked elements are unchanged context.
+
+Also emit Mermaid `classDef` directives as a best-effort visual layer — a renderer that honours them produces colour:
+
+```mermaid
+classDef added    fill:#dcfce7,stroke:#16a34a,stroke-width:2px;
+classDef removed  fill:#fee2e2,stroke:#dc2626,stroke-width:2px,stroke-dasharray:5 5;
+classDef modified fill:#fef3c7,stroke:#d97706,stroke-width:2px;
+class A,B added
+class C removed
+class D modified
+```
+
+Prefixes alone must be self-sufficient: if Miro drops the classDef block, the reviewer still sees what changed from the label text.
+
+##### Legend
+
+After the first diagram (or pair) on the board, place a small text/sticky:
+
+> Legend: `[ADDED]` new in this change · `[REMOVED]` deleted · `[MOD]` modified · unmarked = unchanged context
+
+One legend per code-review board is enough.
+
 **Diagram Selection Guide:**
 
-| Change Type | Diagram Type | Purpose |
-|-------------|--------------|---------|
-| Feature addition | `flowchart` | Show component interactions |
-| Refactoring | `uml_class` | Show structural changes |
-| API/integration | `uml_sequence` | Show interaction flow |
-| Database changes | `entity_relationship` | Show schema modifications |
-| Bug fix | `flowchart` | Show fix location in flow |
-| Data pipeline | `flowchart` | Show data flow |
+| Change Type | Diagram Type | Pattern | Purpose |
+|-------------|--------------|---------|---------|
+| Feature addition (purely additive) | `flowchart` | Single annotated (after) | Show new components and how they wire in |
+| Refactoring | `uml_class` | Side-by-side before/after | Structural rearrangement is the whole point |
+| API/integration change | `uml_sequence` | Side-by-side before/after | Flow shape changes |
+| DB migration / schema change | `entity_relationship` | Side-by-side before/after | Schema delta is the focus |
+| Bug fix | `flowchart` | Single annotated (after) | Mark the fix point in the flow |
+| Data pipeline restructure | `flowchart` | Side-by-side before/after | Data flow shape changes |
+| Mixed / large refactor | per-subsystem | Side-by-side per subsystem | One pair per affected boundary |
 
 **Diagram Positions:**
 
-Position diagrams after the last document. For a typical Large PR with 3 docs:
+A side-by-side pair occupies two adjacent x slots (gap = 2000 between pair members); the next diagram or pair starts another 2000 after the last slot used. A single annotated diagram occupies one slot. Let `N` = last document `x` + 800.
 
-| Diagram | Position | When to Create |
-|---------|----------|----------------|
-| Main flow/architecture | x=3200, y=0 | Always |
-| Component relationships | x=4000, y=0 | Medium+ PRs |
-| Sequence/interaction | x=4800, y=0 | API changes |
-| Data flow | x=5600, y=0 | Data pipeline changes |
-| Before/after comparison | x=6400, y=0 | Major refactoring |
+| Diagram (or pair) | Position(s) | When to create |
+|-------------------|-------------|----------------|
+| Main flow/architecture pair | `before` at x=N, `after` at x=N+2000 | Always |
+| Component relationships pair | next two slots | Medium+ PRs with structural change |
+| Sequence/interaction pair | next two slots | API/integration changes |
+| ER pair | next two slots | Data pipeline / schema changes |
+| Single annotated (additions only) | one slot | Purely additive change, ≤ 3 new elements |
 
-Adjust starting x based on actual number of documents created.
+Adjust `N` based on the actual number of documents created.
 
 **Each diagram should show:**
 - Affected components/modules (highlighted)
 - Data/control flow through changed code
 - Dependencies between changed files
 - Trust boundaries (for security-relevant changes)
-- Where a node corresponds to a single source file, append its URL on a second line of the label so a reader can copy it (paths only — diagram nodes are not clickable). Skip the URL when no remote is available.
+- Where a node corresponds to a single source file, append its URL on a second line of the label so a reader can copy it (paths only — diagram nodes are not clickable). Skip the URL when no remote is available. Use `LINK_BASE_SHA` in URLs on *before* diagrams; use `LINK_SHA` on *after* diagrams.
+- The change markers from §5 "Marking convention" applied to every modified/added/removed element — the diagram or pair must make the delta visible at a glance.
 
 ### 6. Post link back to PR/MR
 
@@ -456,7 +527,7 @@ If the §4.5 bail-out applied, the entire output is the trivial-PR chat message 
 Otherwise, after completion provide:
 1. Link to the Miro board (or frame, if `moveToWidget` was provided)
 2. Confirmation that the PR/MR description was updated, or that we left a comment as a fallback, or that the post step was skipped because the source was local / branchless
-3. Summary of elements created (X docs, Y diagrams, Z table rows) — and which artifact types were intentionally skipped per §4.5, with a one-line reason
+3. Summary of elements created (X docs, Y diagrams as N pairs + M single annotated, Z table rows) — base revision `<short LINK_BASE_SHA>`, head revision `<short LINK_SHA>` — and which artifact types were intentionally skipped per §4.5, with a one-line reason
 4. High-risk files requiring careful review
 5. Security findings (if any critical/high)
 6. Architecture concerns (if any breaking changes)

--- a/copilot-cowork-plugins/miro/skills/miro-code-review/SKILL.md
+++ b/copilot-cowork-plugins/miro/skills/miro-code-review/SKILL.md
@@ -402,7 +402,7 @@ Primary signal is the **label prefix**, because per-element styling is not guara
 
 - `[ADDED] <name>` — element introduced in this change. In an *after* diagram only (omitted from before).
 - `[REMOVED] <name>` — element deleted in this change. In a *before* diagram only (omitted from after).
-- `[MOD] <name>` — element kept but with a meaningful change to signature, body, or relationships. Present in both diagrams; prefix appears in the *after* only.
+- `[UPDATED] <name>` — element kept but with a meaningful change to signature, body, or relationships. Present in both diagrams; prefix appears in the *after* only.
 - Unmarked elements are unchanged context.
 
 Also emit Mermaid `classDef` directives as a best-effort visual layer — a renderer that honours them produces colour:
@@ -410,21 +410,13 @@ Also emit Mermaid `classDef` directives as a best-effort visual layer — a rend
 ```mermaid
 classDef added    fill:#dcfce7,stroke:#16a34a,stroke-width:2px;
 classDef removed  fill:#fee2e2,stroke:#dc2626,stroke-width:2px,stroke-dasharray:5 5;
-classDef modified fill:#fef3c7,stroke:#d97706,stroke-width:2px;
+classDef updated  fill:#fef3c7,stroke:#d97706,stroke-width:2px;
 class A,B added
 class C removed
-class D modified
+class D updated
 ```
 
-Prefixes alone must be self-sufficient: if Miro drops the classDef block, the reviewer still sees what changed from the label text.
-
-##### Legend
-
-After the first diagram (or pair) on the board, place a small text/sticky:
-
-> Legend: `[ADDED]` new in this change · `[REMOVED]` deleted · `[MOD]` modified · unmarked = unchanged context
-
-One legend per code-review board is enough.
+Prefixes alone must be self-sufficient: if Miro drops the classDef block, the reviewer still sees what changed from the label text. Do not create a legend widget on the board — the prefixes are self-explanatory and a separate legend just clutters the layout.
 
 **Diagram Selection Guide:**
 
@@ -527,7 +519,7 @@ If the §4.5 bail-out applied, the entire output is the trivial-PR chat message 
 Otherwise, after completion provide:
 1. Link to the Miro board (or frame, if `moveToWidget` was provided)
 2. Confirmation that the PR/MR description was updated, or that we left a comment as a fallback, or that the post step was skipped because the source was local / branchless
-3. Summary of elements created (X docs, Y diagrams as N pairs + M single annotated, Z table rows) — base revision `<short LINK_BASE_SHA>`, head revision `<short LINK_SHA>` — and which artifact types were intentionally skipped per §4.5, with a one-line reason
+3. Summary of elements created (X docs, Y diagrams as N pairs + M single annotated, Z table rows). Mention base revision `<short LINK_BASE_SHA>` and head revision `<short LINK_SHA>` in this chat summary only — do **not** place these SHAs on the Miro board. Also note which artifact types were intentionally skipped per §4.5, with a one-line reason.
 4. High-risk files requiring careful review
 5. Security findings (if any critical/high)
 6. Architecture concerns (if any breaking changes)

--- a/copilot-cowork-plugins/miro/skills/miro-code-review/SKILL.md
+++ b/copilot-cowork-plugins/miro/skills/miro-code-review/SKILL.md
@@ -78,6 +78,40 @@ git log $DEFAULT_BRANCH..HEAD --oneline
 git diff $DEFAULT_BRANCH...HEAD
 ```
 
+#### Determine the source-link base URL
+
+Capture once and reuse for every file reference in §5 (table cells, document bullets, diagram labels). Pin links to the head SHA so they survive force-pushes.
+
+Record:
+
+- `LINK_HOST` — host from §1 (e.g. `github.com`, `gitlab.com`, self-hosted)
+- `LINK_OWNER` / `LINK_REPO` (GitHub-style) **or** `LINK_GROUP` / `LINK_PROJECT` (GitLab-style)
+- `LINK_SHA` — PR/MR head commit SHA, fetched per platform:
+
+```bash
+# GitHub
+LINK_SHA=$(gh pr view $PR_NUMBER --json headRefOid -q .headRefOid)
+# external repo: add --repo $OWNER/$REPO
+
+# GitLab
+LINK_SHA=$(glab mr view $MR_NUMBER -F json | jq -r '.diff_refs.head_sha // .sha')
+# external project: add -R $GROUP/$PROJECT
+
+# Local diff or branch comparison
+LINK_SHA=$(git rev-parse HEAD)
+```
+
+REST fallback: read `head.sha` (GitHub) or `diff_refs.head_sha` (GitLab) from the same JSON payload already fetched above — no extra round-trip needed.
+
+- `LINK_TEMPLATE` — pick by host shape; substitute `{path}` per reference, append `#L<start>-L<end>` line anchors when calling out a specific hunk:
+  - GitHub-style: `https://{host}/{owner}/{repo}/blob/{sha}/{path}` (anchor: `#L{a}-L{b}`)
+  - GitLab-style: `https://{host}/{group}/{project}/-/blob/{sha}/{path}` (anchor: `#L{a}-{b}`)
+  - Bitbucket-style (example pattern, not exhaustive): `https://{host}/{workspace}/{repo}/src/{sha}/{path}`
+
+**No-remote sources** (`local changes`, or a branch with no pushed remote / no PR): set `LINK_TEMPLATE=""` and announce in chat once: `"No remote URL available — file references shown as plain paths."` Do not invent URLs.
+
+State the chosen template in chat before creating artifacts, e.g.: `Source links: https://github.com/acme/api/blob/<sha>/{path}`.
+
 ### 3. Analyze Changes
 
 For each changed file, determine:
@@ -110,9 +144,55 @@ For each changed file, determine:
 | **Medium** | API changes, configuration, shared utilities, new dependencies, data model changes |
 | **Low** | Tests, documentation, styling, localization, internal refactoring |
 
+### 4.5 Triage: decide what (if anything) to create
+
+Every artifact must earn its place. Before doing any creation work, decide whether the PR is worth visualizing at all and which artifact types would actually help a reviewer.
+
+**Bail-out rule.** If **all** of the following hold, create no Miro artifacts and report only in chat:
+
+- ≤ 2 files changed, AND
+- < 20 lines changed (additions + deletions combined), AND
+- No file marked **High** risk in §4, AND
+- No security-sensitive paths touched (auth, crypto, config, migrations).
+
+In that case, the entire skill output is a single chat message of the form:
+
+> PR is trivial (N files, ±M lines, no high-risk areas). Skipping Miro visualization — a board would not add review value. PR/MR description was not modified.
+
+Skip §5 and §6 entirely.
+
+**Value gate (per artifact).** When the bail-out does not apply, still only create an artifact if it tells a reviewer something the diff itself does not already make obvious:
+
+- **Table** — create when ≥ 3 files changed *or* mixed risk levels exist. For 1–2 file PRs that don't bail out, skip the table.
+- **Summary doc** — create when the PR has non-trivial intent that isn't already captured in the PR title/body, OR when ≥ 2 high-risk items need callouts. Skip if it would just paraphrase the PR description.
+- **Architecture doc** — create only if structural changes are detected (new modules, modified public interfaces, dependency changes, breaking changes). Skip otherwise.
+- **Security doc** — create only when security-sensitive paths are touched (see §3 "Security Analysis"). Never create as a checklist-only artifact.
+- **Diagram** — create only when the change involves multi-component flow, control/data path changes, or structural relationships that are hard to grasp from the diff. Explicitly skip diagrams that would be a single node, two nodes with one arrow, or a literal restatement of the diff.
+
+**Announce the plan in chat** before creating anything, e.g.:
+
+> Plan: 1 table, 1 summary doc, no diagrams (changes are localized to a single function).
+
+This makes the triage visible and lets the user redirect before any board content is created.
+
 ### 5. Create Miro Board Content
 
-**IMPORTANT: Scale content based on PR size.** Create multiple documents and diagrams for larger PRs.
+**Principle:** every artifact must earn its place. If an artifact would not help a reviewer understand the PR faster than the diff alone, do not create it. See §4.5 for the triage rules.
+
+**Scale content *up to* these caps based on PR size, and apply the §4.5 value gates — fewer artifacts is fine.**
+
+#### Linking conventions
+
+Every file reference produced in §5 must be a clickable hyperlink to the source platform when a base URL is available. Use the `LINK_TEMPLATE` and `LINK_SHA` captured in §2.
+
+- **When `LINK_TEMPLATE` is set** (PR/MR or branch with a known remote): build the URL by substituting the file `{path}`. Add a line anchor `#L<start>-L<end>` when calling out a specific hunk (high-risk files, security findings, architecture callouts). Resolve start/end from the diff hunks captured in §2 (`@@ -a,b +c,d @@`, use the new-file range). Skip the anchor if the reference spans multiple non-contiguous hunks.
+- **When `LINK_TEMPLATE` is empty** (`local changes` or no remote): render every file reference as a plain path. Do not invent URLs.
+
+Per-artifact rules:
+
+- **Table → File column**: put the full URL as the cell content. Miro renders URLs in text cells as clickable links. With no remote, put the plain path.
+- **Documents**: use markdown links — `[path/to/file.ts](url)` for whole-file references and `[path/to/file.ts:42-58](url#L42-L58)` for hunk references. Apply this in *every* file mention (Overview, Key Changes, High-Risk Areas, Architecture > New Components / Modified Interfaces, Security > Security-Sensitive Changes, etc.).
+- **Diagrams**: keep node labels as plain paths — the Miro diagram tool does not document clickable nodes. When a node corresponds to a single source file, append the URL as a second line in the node label so a reader can copy it.
 
 **Positioning Notes:**
 
@@ -130,12 +210,13 @@ Use a **horizontal row layout** because tables and docs have fixed width but var
 
 #### Scaling Guidelines
 
-| PR Size | Files | Documents | Diagrams |
-|---------|-------|-----------|----------|
-| Small | 1-5 | 1 summary | 1 flow diagram |
-| Medium | 6-15 | 2 docs (summary + deep-dive) | 2-3 diagrams |
-| Large | 16-30 | 3 docs (summary + architecture + security) | 3-4 diagrams |
-| Very Large | 30+ | 4+ docs (by subsystem/area) | 5+ diagrams |
+| PR Size | Files | LOC (±) | Documents | Diagrams |
+|---------|-------|---------|-----------|----------|
+| Trivial | 1–2 | < 20 | none (bail out per §4.5) | none |
+| Small | 1–5 | < 100 | 0–1 summary | 0–1 flow |
+| Medium | 6–15 | < 500 | 1–2 (summary + deep-dive if needed) | 1–3 |
+| Large | 16–30 | < 1500 | 2–3 (summary + architecture + security if applicable) | 2–4 |
+| Very Large | 30+ | ≥ 1500 | 3+ (by subsystem) | 3+ |
 
 ---
 
@@ -146,7 +227,7 @@ Create first (appears at board center). Use Miro MCP tool to create a table with
 | Column | Type | Options |
 |--------|------|---------|
 | Status | select | Added (#00FF00), Modified (#FFA500), Deleted (#FF0000) |
-| File | text | File path |
+| File | text | Linked file URL (Miro auto-renders URLs in text cells as clickable). Use the plain path when no remote URL is available — see §5 "Linking conventions". |
 | Change | text | Brief summary of changes and key review points |
 | Risk | select | Low (#00FF00), Medium (#FFA500), High (#FF0000) |
 
@@ -160,7 +241,7 @@ For very large PRs (30+ files), create separate tables:
 
 **Document 1: Main Summary (x=800, y=0)**
 
-Always create this document:
+Create when the §4.5 value gate for the summary doc passes. Skip if the PR description already covers the same ground.
 
 ```markdown
 # Code Review: [PR Title]
@@ -178,7 +259,7 @@ Always create this document:
 - [Bullet points of significant changes]
 
 ## High-Risk Areas
-- [Files/components requiring careful review]
+- [path/to/file.ts:42-58](url#L42-L58) — [reason this file is high-risk]
 
 ## Review Checklist
 - [ ] Logic correctness verified
@@ -193,7 +274,7 @@ Always create this document:
 
 **Document 2: Architecture Analysis (x=1600, y=0)**
 
-Create for Medium+ PRs or when structural changes detected:
+Create only when the §4.5 architecture-doc value gate passes — i.e. the diff introduces new modules, modifies public interfaces, changes dependencies, or adds breaking changes. Skip otherwise, even on Medium/Large PRs.
 
 ```markdown
 # Architecture Analysis
@@ -201,13 +282,13 @@ Create for Medium+ PRs or when structural changes detected:
 ## Structural Changes
 
 ### New Components
-- [List new modules, services, classes]
+- [path/to/new_module.ts](url) — [purpose / role]
 
 ### Modified Interfaces
-- [API changes, contract modifications]
+- [path/to/api.ts:120-180](url#L120-L180) — [API change / contract modification]
 
 ### Dependency Changes
-- [New, removed, or updated dependencies]
+- [package.json](url) — [added/removed/updated dependency]
 
 ## Design Patterns
 - [Patterns introduced or modified]
@@ -225,7 +306,7 @@ Create for Medium+ PRs or when structural changes detected:
 
 **Document 3: Security Analysis (x=2400, y=0)**
 
-Create for Large+ PRs or when security-sensitive code detected:
+Create only when security-sensitive paths are touched (auth, crypto, config, migrations, input handling). Never create as a checklist-only artifact on a PR with no security-relevant diff.
 
 ```markdown
 # Security Analysis
@@ -233,9 +314,9 @@ Create for Large+ PRs or when security-sensitive code detected:
 **Risk Score:** [Critical/High/Medium/Low]
 
 ## Security-Sensitive Changes
-- [Auth/authz modifications]
-- [Data handling changes]
-- [API exposure changes]
+- [path/to/auth.ts:30-95](url#L30-L95) — [auth/authz modification]
+- [path/to/handler.ts:10-40](url#L10-L40) — [data handling change]
+- [path/to/route.ts:200-220](url#L200-L220) — [API exposure change]
 
 ## Vulnerability Assessment
 
@@ -306,6 +387,7 @@ Adjust starting x based on actual number of documents created.
 - Data/control flow through changed code
 - Dependencies between changed files
 - Trust boundaries (for security-relevant changes)
+- Where a node corresponds to a single source file, append its URL on a second line of the label so a reader can copy it (paths only — diagram nodes are not clickable). Skip the URL when no remote is available.
 
 ### 6. Post link back to PR/MR
 
@@ -369,10 +451,12 @@ If editing the description fails because the user lacks permission (for example,
 
 ## Output
 
-After completion, provide:
+If the §4.5 bail-out applied, the entire output is the trivial-PR chat message — no board link, no description update, nothing else.
+
+Otherwise, after completion provide:
 1. Link to the Miro board (or frame, if `moveToWidget` was provided)
 2. Confirmation that the PR/MR description was updated, or that we left a comment as a fallback, or that the post step was skipped because the source was local / branchless
-3. Summary of elements created (X docs, Y diagrams, Z table rows)
+3. Summary of elements created (X docs, Y diagrams, Z table rows) — and which artifact types were intentionally skipped per §4.5, with a one-line reason
 4. High-risk files requiring careful review
 5. Security findings (if any critical/high)
 6. Architecture concerns (if any breaking changes)

--- a/cursor-plugins/miro/.cursor-plugin/plugin.json
+++ b/cursor-plugins/miro/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "miro",
   "displayName": "Miro",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Secure access to Miro boards. Enables AI to read board context, create diagrams, and generate code with enterprise-grade security.",
   "author": {
     "name": "Miro",

--- a/cursor-plugins/miro/.cursor-plugin/plugin.json
+++ b/cursor-plugins/miro/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "miro",
   "displayName": "Miro",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "description": "Secure access to Miro boards. Enables AI to read board context, create diagrams, and generate code with enterprise-grade security.",
   "author": {
     "name": "Miro",

--- a/cursor-plugins/miro/.cursor-plugin/plugin.json
+++ b/cursor-plugins/miro/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "miro",
   "displayName": "Miro",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Secure access to Miro boards. Enables AI to read board context, create diagrams, and generate code with enterprise-grade security.",
   "author": {
     "name": "Miro",

--- a/cursor-plugins/miro/skills/miro-code-review/SKILL.md
+++ b/cursor-plugins/miro/skills/miro-code-review/SKILL.md
@@ -103,6 +103,32 @@ LINK_SHA=$(git rev-parse HEAD)
 
 REST fallback: read `head.sha` (GitHub) or `diff_refs.head_sha` (GitLab) from the same JSON payload already fetched above — no extra round-trip needed.
 
+- `LINK_BASE_SHA` — base commit SHA (the PR/MR target tip, or the merge-base for branch comparisons). Required by §5 "Showing change" to render before/after diagrams and to hyperlink "before" nodes to the prior revision:
+
+```bash
+# GitHub
+LINK_BASE_SHA=$(gh pr view $PR_NUMBER --json baseRefOid -q .baseRefOid)
+# external repo: add --repo $OWNER/$REPO
+
+# GitLab
+LINK_BASE_SHA=$(glab mr view $MR_NUMBER -F json | jq -r '.diff_refs.base_sha // .target_branch')
+# external project: add -R $GROUP/$PROJECT
+
+# Local diff (uncommitted): base is the current HEAD itself
+LINK_BASE_SHA=$(git rev-parse HEAD)
+
+# Branch comparison
+LINK_BASE_SHA=$(git merge-base origin/$DEFAULT_BRANCH HEAD)
+```
+
+To extract the pre-change content of a single file (needed when the unified diff alone doesn't carry enough surrounding structure, e.g. class hierarchies):
+
+```bash
+git show $LINK_BASE_SHA:path/to/file
+```
+
+If the base SHA is unreachable (shallow clone, history pruned, target branch not fetched), skip "before" diagrams and announce once in chat: `"base revision unavailable — only 'after' diagrams created"`.
+
 - `LINK_TEMPLATE` — pick by host shape; substitute `{path}` per reference, append `#L<start>-L<end>` line anchors when calling out a specific hunk:
   - GitHub-style: `https://{host}/{owner}/{repo}/blob/{sha}/{path}` (anchor: `#L{a}-L{b}`)
   - GitLab-style: `https://{host}/{group}/{project}/-/blob/{sha}/{path}` (anchor: `#L{a}-{b}`)
@@ -167,7 +193,7 @@ Skip §5 and §6 entirely.
 - **Summary doc** — create when the PR has non-trivial intent that isn't already captured in the PR title/body, OR when ≥ 2 high-risk items need callouts. Skip if it would just paraphrase the PR description.
 - **Architecture doc** — create only if structural changes are detected (new modules, modified public interfaces, dependency changes, breaking changes). Skip otherwise.
 - **Security doc** — create only when security-sensitive paths are touched (see §3 "Security Analysis"). Never create as a checklist-only artifact.
-- **Diagram** — create only when the change involves multi-component flow, control/data path changes, or structural relationships that are hard to grasp from the diff. Explicitly skip diagrams that would be a single node, two nodes with one arrow, or a literal restatement of the diff.
+- **Diagram** — create only when the change involves multi-component flow, control/data path changes, or structural relationships that are hard to grasp from the diff. Render as a **side-by-side before/after pair** by default (see §5 "Showing change"); use a **single annotated "after" diagram** only when the change is purely additive and touches ≤ 3 elements. Explicitly skip diagrams that would be a single node, two nodes with one arrow, or a literal restatement of the diff.
 
 **Announce the plan in chat** before creating anything, e.g.:
 
@@ -217,6 +243,8 @@ Use a **horizontal row layout** because tables and docs have fixed width but var
 | Medium | 6–15 | < 500 | 1–2 (summary + deep-dive if needed) | 1–3 |
 | Large | 16–30 | < 1500 | 2–3 (summary + architecture + security if applicable) | 2–4 |
 | Very Large | 30+ | ≥ 1500 | 3+ (by subsystem) | 3+ |
+
+> A side-by-side before/after pair counts as **one** diagram for the budgets above — the column limits conceptual artifacts, not raw board widgets.
 
 ---
 
@@ -357,37 +385,80 @@ For Very Large PRs, create per-subsystem documents (continue incrementing x by 8
 
 Create diagrams based on the type of changes. Position after the last document (continue x increments of 800).
 
+##### Showing change: before/after vs. annotated
+
+Every diagram must make the *delta* visible at a glance, not just the post-change state.
+
+- **Default: side-by-side before/after pair.** Build two diagrams of the same type with the same DSL conventions and place them adjacently on the same y-row. Build the "before" from the `LINK_BASE_SHA` revision (use `git show $LINK_BASE_SHA:path` when the unified diff doesn't carry enough surrounding structure), and the "after" from `LINK_SHA`.
+- **Single annotated "after" diagram instead** when *all* of these hold:
+  - The change is purely additive (no deleted files, no removed classes/components, no removed edges in the relevant subsystem), AND
+  - The additions do not rearrange existing relationships (no rewired callers, no moved responsibilities), AND
+  - There are ≤ 3 new nodes/edges to mark.
+- If `LINK_BASE_SHA` is unreachable (shallow clone, history pruned), degrade every pair to a single annotated "after" diagram and reuse the chat announcement from §2.
+
+##### Marking convention
+
+Primary signal is the **label prefix**, because per-element styling is not guaranteed by the Miro Mermaid renderer:
+
+- `[ADDED] <name>` — element introduced in this change. In an *after* diagram only (omitted from before).
+- `[REMOVED] <name>` — element deleted in this change. In a *before* diagram only (omitted from after).
+- `[MOD] <name>` — element kept but with a meaningful change to signature, body, or relationships. Present in both diagrams; prefix appears in the *after* only.
+- Unmarked elements are unchanged context.
+
+Also emit Mermaid `classDef` directives as a best-effort visual layer — a renderer that honours them produces colour:
+
+```mermaid
+classDef added    fill:#dcfce7,stroke:#16a34a,stroke-width:2px;
+classDef removed  fill:#fee2e2,stroke:#dc2626,stroke-width:2px,stroke-dasharray:5 5;
+classDef modified fill:#fef3c7,stroke:#d97706,stroke-width:2px;
+class A,B added
+class C removed
+class D modified
+```
+
+Prefixes alone must be self-sufficient: if Miro drops the classDef block, the reviewer still sees what changed from the label text.
+
+##### Legend
+
+After the first diagram (or pair) on the board, place a small text/sticky:
+
+> Legend: `[ADDED]` new in this change · `[REMOVED]` deleted · `[MOD]` modified · unmarked = unchanged context
+
+One legend per code-review board is enough.
+
 **Diagram Selection Guide:**
 
-| Change Type | Diagram Type | Purpose |
-|-------------|--------------|---------|
-| Feature addition | `flowchart` | Show component interactions |
-| Refactoring | `uml_class` | Show structural changes |
-| API/integration | `uml_sequence` | Show interaction flow |
-| Database changes | `entity_relationship` | Show schema modifications |
-| Bug fix | `flowchart` | Show fix location in flow |
-| Data pipeline | `flowchart` | Show data flow |
+| Change Type | Diagram Type | Pattern | Purpose |
+|-------------|--------------|---------|---------|
+| Feature addition (purely additive) | `flowchart` | Single annotated (after) | Show new components and how they wire in |
+| Refactoring | `uml_class` | Side-by-side before/after | Structural rearrangement is the whole point |
+| API/integration change | `uml_sequence` | Side-by-side before/after | Flow shape changes |
+| DB migration / schema change | `entity_relationship` | Side-by-side before/after | Schema delta is the focus |
+| Bug fix | `flowchart` | Single annotated (after) | Mark the fix point in the flow |
+| Data pipeline restructure | `flowchart` | Side-by-side before/after | Data flow shape changes |
+| Mixed / large refactor | per-subsystem | Side-by-side per subsystem | One pair per affected boundary |
 
 **Diagram Positions:**
 
-Position diagrams after the last document. For a typical Large PR with 3 docs:
+A side-by-side pair occupies two adjacent x slots (gap = 2000 between pair members); the next diagram or pair starts another 2000 after the last slot used. A single annotated diagram occupies one slot. Let `N` = last document `x` + 800.
 
-| Diagram | Position | When to Create |
-|---------|----------|----------------|
-| Main flow/architecture | x=3200, y=0 | Always |
-| Component relationships | x=4000, y=0 | Medium+ PRs |
-| Sequence/interaction | x=4800, y=0 | API changes |
-| Data flow | x=5600, y=0 | Data pipeline changes |
-| Before/after comparison | x=6400, y=0 | Major refactoring |
+| Diagram (or pair) | Position(s) | When to create |
+|-------------------|-------------|----------------|
+| Main flow/architecture pair | `before` at x=N, `after` at x=N+2000 | Always |
+| Component relationships pair | next two slots | Medium+ PRs with structural change |
+| Sequence/interaction pair | next two slots | API/integration changes |
+| ER pair | next two slots | Data pipeline / schema changes |
+| Single annotated (additions only) | one slot | Purely additive change, ≤ 3 new elements |
 
-Adjust starting x based on actual number of documents created.
+Adjust `N` based on the actual number of documents created.
 
 **Each diagram should show:**
 - Affected components/modules (highlighted)
 - Data/control flow through changed code
 - Dependencies between changed files
 - Trust boundaries (for security-relevant changes)
-- Where a node corresponds to a single source file, append its URL on a second line of the label so a reader can copy it (paths only — diagram nodes are not clickable). Skip the URL when no remote is available.
+- Where a node corresponds to a single source file, append its URL on a second line of the label so a reader can copy it (paths only — diagram nodes are not clickable). Skip the URL when no remote is available. Use `LINK_BASE_SHA` in URLs on *before* diagrams; use `LINK_SHA` on *after* diagrams.
+- The change markers from §5 "Marking convention" applied to every modified/added/removed element — the diagram or pair must make the delta visible at a glance.
 
 ### 6. Post link back to PR/MR
 
@@ -456,7 +527,7 @@ If the §4.5 bail-out applied, the entire output is the trivial-PR chat message 
 Otherwise, after completion provide:
 1. Link to the Miro board (or frame, if `moveToWidget` was provided)
 2. Confirmation that the PR/MR description was updated, or that we left a comment as a fallback, or that the post step was skipped because the source was local / branchless
-3. Summary of elements created (X docs, Y diagrams, Z table rows) — and which artifact types were intentionally skipped per §4.5, with a one-line reason
+3. Summary of elements created (X docs, Y diagrams as N pairs + M single annotated, Z table rows) — base revision `<short LINK_BASE_SHA>`, head revision `<short LINK_SHA>` — and which artifact types were intentionally skipped per §4.5, with a one-line reason
 4. High-risk files requiring careful review
 5. Security findings (if any critical/high)
 6. Architecture concerns (if any breaking changes)

--- a/cursor-plugins/miro/skills/miro-code-review/SKILL.md
+++ b/cursor-plugins/miro/skills/miro-code-review/SKILL.md
@@ -402,7 +402,7 @@ Primary signal is the **label prefix**, because per-element styling is not guara
 
 - `[ADDED] <name>` — element introduced in this change. In an *after* diagram only (omitted from before).
 - `[REMOVED] <name>` — element deleted in this change. In a *before* diagram only (omitted from after).
-- `[MOD] <name>` — element kept but with a meaningful change to signature, body, or relationships. Present in both diagrams; prefix appears in the *after* only.
+- `[UPDATED] <name>` — element kept but with a meaningful change to signature, body, or relationships. Present in both diagrams; prefix appears in the *after* only.
 - Unmarked elements are unchanged context.
 
 Also emit Mermaid `classDef` directives as a best-effort visual layer — a renderer that honours them produces colour:
@@ -410,21 +410,13 @@ Also emit Mermaid `classDef` directives as a best-effort visual layer — a rend
 ```mermaid
 classDef added    fill:#dcfce7,stroke:#16a34a,stroke-width:2px;
 classDef removed  fill:#fee2e2,stroke:#dc2626,stroke-width:2px,stroke-dasharray:5 5;
-classDef modified fill:#fef3c7,stroke:#d97706,stroke-width:2px;
+classDef updated  fill:#fef3c7,stroke:#d97706,stroke-width:2px;
 class A,B added
 class C removed
-class D modified
+class D updated
 ```
 
-Prefixes alone must be self-sufficient: if Miro drops the classDef block, the reviewer still sees what changed from the label text.
-
-##### Legend
-
-After the first diagram (or pair) on the board, place a small text/sticky:
-
-> Legend: `[ADDED]` new in this change · `[REMOVED]` deleted · `[MOD]` modified · unmarked = unchanged context
-
-One legend per code-review board is enough.
+Prefixes alone must be self-sufficient: if Miro drops the classDef block, the reviewer still sees what changed from the label text. Do not create a legend widget on the board — the prefixes are self-explanatory and a separate legend just clutters the layout.
 
 **Diagram Selection Guide:**
 
@@ -527,7 +519,7 @@ If the §4.5 bail-out applied, the entire output is the trivial-PR chat message 
 Otherwise, after completion provide:
 1. Link to the Miro board (or frame, if `moveToWidget` was provided)
 2. Confirmation that the PR/MR description was updated, or that we left a comment as a fallback, or that the post step was skipped because the source was local / branchless
-3. Summary of elements created (X docs, Y diagrams as N pairs + M single annotated, Z table rows) — base revision `<short LINK_BASE_SHA>`, head revision `<short LINK_SHA>` — and which artifact types were intentionally skipped per §4.5, with a one-line reason
+3. Summary of elements created (X docs, Y diagrams as N pairs + M single annotated, Z table rows). Mention base revision `<short LINK_BASE_SHA>` and head revision `<short LINK_SHA>` in this chat summary only — do **not** place these SHAs on the Miro board. Also note which artifact types were intentionally skipped per §4.5, with a one-line reason.
 4. High-risk files requiring careful review
 5. Security findings (if any critical/high)
 6. Architecture concerns (if any breaking changes)

--- a/cursor-plugins/miro/skills/miro-code-review/SKILL.md
+++ b/cursor-plugins/miro/skills/miro-code-review/SKILL.md
@@ -78,6 +78,40 @@ git log $DEFAULT_BRANCH..HEAD --oneline
 git diff $DEFAULT_BRANCH...HEAD
 ```
 
+#### Determine the source-link base URL
+
+Capture once and reuse for every file reference in §5 (table cells, document bullets, diagram labels). Pin links to the head SHA so they survive force-pushes.
+
+Record:
+
+- `LINK_HOST` — host from §1 (e.g. `github.com`, `gitlab.com`, self-hosted)
+- `LINK_OWNER` / `LINK_REPO` (GitHub-style) **or** `LINK_GROUP` / `LINK_PROJECT` (GitLab-style)
+- `LINK_SHA` — PR/MR head commit SHA, fetched per platform:
+
+```bash
+# GitHub
+LINK_SHA=$(gh pr view $PR_NUMBER --json headRefOid -q .headRefOid)
+# external repo: add --repo $OWNER/$REPO
+
+# GitLab
+LINK_SHA=$(glab mr view $MR_NUMBER -F json | jq -r '.diff_refs.head_sha // .sha')
+# external project: add -R $GROUP/$PROJECT
+
+# Local diff or branch comparison
+LINK_SHA=$(git rev-parse HEAD)
+```
+
+REST fallback: read `head.sha` (GitHub) or `diff_refs.head_sha` (GitLab) from the same JSON payload already fetched above — no extra round-trip needed.
+
+- `LINK_TEMPLATE` — pick by host shape; substitute `{path}` per reference, append `#L<start>-L<end>` line anchors when calling out a specific hunk:
+  - GitHub-style: `https://{host}/{owner}/{repo}/blob/{sha}/{path}` (anchor: `#L{a}-L{b}`)
+  - GitLab-style: `https://{host}/{group}/{project}/-/blob/{sha}/{path}` (anchor: `#L{a}-{b}`)
+  - Bitbucket-style (example pattern, not exhaustive): `https://{host}/{workspace}/{repo}/src/{sha}/{path}`
+
+**No-remote sources** (`local changes`, or a branch with no pushed remote / no PR): set `LINK_TEMPLATE=""` and announce in chat once: `"No remote URL available — file references shown as plain paths."` Do not invent URLs.
+
+State the chosen template in chat before creating artifacts, e.g.: `Source links: https://github.com/acme/api/blob/<sha>/{path}`.
+
 ### 3. Analyze Changes
 
 For each changed file, determine:
@@ -110,9 +144,55 @@ For each changed file, determine:
 | **Medium** | API changes, configuration, shared utilities, new dependencies, data model changes |
 | **Low** | Tests, documentation, styling, localization, internal refactoring |
 
+### 4.5 Triage: decide what (if anything) to create
+
+Every artifact must earn its place. Before doing any creation work, decide whether the PR is worth visualizing at all and which artifact types would actually help a reviewer.
+
+**Bail-out rule.** If **all** of the following hold, create no Miro artifacts and report only in chat:
+
+- ≤ 2 files changed, AND
+- < 20 lines changed (additions + deletions combined), AND
+- No file marked **High** risk in §4, AND
+- No security-sensitive paths touched (auth, crypto, config, migrations).
+
+In that case, the entire skill output is a single chat message of the form:
+
+> PR is trivial (N files, ±M lines, no high-risk areas). Skipping Miro visualization — a board would not add review value. PR/MR description was not modified.
+
+Skip §5 and §6 entirely.
+
+**Value gate (per artifact).** When the bail-out does not apply, still only create an artifact if it tells a reviewer something the diff itself does not already make obvious:
+
+- **Table** — create when ≥ 3 files changed *or* mixed risk levels exist. For 1–2 file PRs that don't bail out, skip the table.
+- **Summary doc** — create when the PR has non-trivial intent that isn't already captured in the PR title/body, OR when ≥ 2 high-risk items need callouts. Skip if it would just paraphrase the PR description.
+- **Architecture doc** — create only if structural changes are detected (new modules, modified public interfaces, dependency changes, breaking changes). Skip otherwise.
+- **Security doc** — create only when security-sensitive paths are touched (see §3 "Security Analysis"). Never create as a checklist-only artifact.
+- **Diagram** — create only when the change involves multi-component flow, control/data path changes, or structural relationships that are hard to grasp from the diff. Explicitly skip diagrams that would be a single node, two nodes with one arrow, or a literal restatement of the diff.
+
+**Announce the plan in chat** before creating anything, e.g.:
+
+> Plan: 1 table, 1 summary doc, no diagrams (changes are localized to a single function).
+
+This makes the triage visible and lets the user redirect before any board content is created.
+
 ### 5. Create Miro Board Content
 
-**IMPORTANT: Scale content based on PR size.** Create multiple documents and diagrams for larger PRs.
+**Principle:** every artifact must earn its place. If an artifact would not help a reviewer understand the PR faster than the diff alone, do not create it. See §4.5 for the triage rules.
+
+**Scale content *up to* these caps based on PR size, and apply the §4.5 value gates — fewer artifacts is fine.**
+
+#### Linking conventions
+
+Every file reference produced in §5 must be a clickable hyperlink to the source platform when a base URL is available. Use the `LINK_TEMPLATE` and `LINK_SHA` captured in §2.
+
+- **When `LINK_TEMPLATE` is set** (PR/MR or branch with a known remote): build the URL by substituting the file `{path}`. Add a line anchor `#L<start>-L<end>` when calling out a specific hunk (high-risk files, security findings, architecture callouts). Resolve start/end from the diff hunks captured in §2 (`@@ -a,b +c,d @@`, use the new-file range). Skip the anchor if the reference spans multiple non-contiguous hunks.
+- **When `LINK_TEMPLATE` is empty** (`local changes` or no remote): render every file reference as a plain path. Do not invent URLs.
+
+Per-artifact rules:
+
+- **Table → File column**: put the full URL as the cell content. Miro renders URLs in text cells as clickable links. With no remote, put the plain path.
+- **Documents**: use markdown links — `[path/to/file.ts](url)` for whole-file references and `[path/to/file.ts:42-58](url#L42-L58)` for hunk references. Apply this in *every* file mention (Overview, Key Changes, High-Risk Areas, Architecture > New Components / Modified Interfaces, Security > Security-Sensitive Changes, etc.).
+- **Diagrams**: keep node labels as plain paths — the Miro diagram tool does not document clickable nodes. When a node corresponds to a single source file, append the URL as a second line in the node label so a reader can copy it.
 
 **Positioning Notes:**
 
@@ -130,12 +210,13 @@ Use a **horizontal row layout** because tables and docs have fixed width but var
 
 #### Scaling Guidelines
 
-| PR Size | Files | Documents | Diagrams |
-|---------|-------|-----------|----------|
-| Small | 1-5 | 1 summary | 1 flow diagram |
-| Medium | 6-15 | 2 docs (summary + deep-dive) | 2-3 diagrams |
-| Large | 16-30 | 3 docs (summary + architecture + security) | 3-4 diagrams |
-| Very Large | 30+ | 4+ docs (by subsystem/area) | 5+ diagrams |
+| PR Size | Files | LOC (±) | Documents | Diagrams |
+|---------|-------|---------|-----------|----------|
+| Trivial | 1–2 | < 20 | none (bail out per §4.5) | none |
+| Small | 1–5 | < 100 | 0–1 summary | 0–1 flow |
+| Medium | 6–15 | < 500 | 1–2 (summary + deep-dive if needed) | 1–3 |
+| Large | 16–30 | < 1500 | 2–3 (summary + architecture + security if applicable) | 2–4 |
+| Very Large | 30+ | ≥ 1500 | 3+ (by subsystem) | 3+ |
 
 ---
 
@@ -146,7 +227,7 @@ Create first (appears at board center). Use Miro MCP tool to create a table with
 | Column | Type | Options |
 |--------|------|---------|
 | Status | select | Added (#00FF00), Modified (#FFA500), Deleted (#FF0000) |
-| File | text | File path |
+| File | text | Linked file URL (Miro auto-renders URLs in text cells as clickable). Use the plain path when no remote URL is available — see §5 "Linking conventions". |
 | Change | text | Brief summary of changes and key review points |
 | Risk | select | Low (#00FF00), Medium (#FFA500), High (#FF0000) |
 
@@ -160,7 +241,7 @@ For very large PRs (30+ files), create separate tables:
 
 **Document 1: Main Summary (x=800, y=0)**
 
-Always create this document:
+Create when the §4.5 value gate for the summary doc passes. Skip if the PR description already covers the same ground.
 
 ```markdown
 # Code Review: [PR Title]
@@ -178,7 +259,7 @@ Always create this document:
 - [Bullet points of significant changes]
 
 ## High-Risk Areas
-- [Files/components requiring careful review]
+- [path/to/file.ts:42-58](url#L42-L58) — [reason this file is high-risk]
 
 ## Review Checklist
 - [ ] Logic correctness verified
@@ -193,7 +274,7 @@ Always create this document:
 
 **Document 2: Architecture Analysis (x=1600, y=0)**
 
-Create for Medium+ PRs or when structural changes detected:
+Create only when the §4.5 architecture-doc value gate passes — i.e. the diff introduces new modules, modifies public interfaces, changes dependencies, or adds breaking changes. Skip otherwise, even on Medium/Large PRs.
 
 ```markdown
 # Architecture Analysis
@@ -201,13 +282,13 @@ Create for Medium+ PRs or when structural changes detected:
 ## Structural Changes
 
 ### New Components
-- [List new modules, services, classes]
+- [path/to/new_module.ts](url) — [purpose / role]
 
 ### Modified Interfaces
-- [API changes, contract modifications]
+- [path/to/api.ts:120-180](url#L120-L180) — [API change / contract modification]
 
 ### Dependency Changes
-- [New, removed, or updated dependencies]
+- [package.json](url) — [added/removed/updated dependency]
 
 ## Design Patterns
 - [Patterns introduced or modified]
@@ -225,7 +306,7 @@ Create for Medium+ PRs or when structural changes detected:
 
 **Document 3: Security Analysis (x=2400, y=0)**
 
-Create for Large+ PRs or when security-sensitive code detected:
+Create only when security-sensitive paths are touched (auth, crypto, config, migrations, input handling). Never create as a checklist-only artifact on a PR with no security-relevant diff.
 
 ```markdown
 # Security Analysis
@@ -233,9 +314,9 @@ Create for Large+ PRs or when security-sensitive code detected:
 **Risk Score:** [Critical/High/Medium/Low]
 
 ## Security-Sensitive Changes
-- [Auth/authz modifications]
-- [Data handling changes]
-- [API exposure changes]
+- [path/to/auth.ts:30-95](url#L30-L95) — [auth/authz modification]
+- [path/to/handler.ts:10-40](url#L10-L40) — [data handling change]
+- [path/to/route.ts:200-220](url#L200-L220) — [API exposure change]
 
 ## Vulnerability Assessment
 
@@ -306,6 +387,7 @@ Adjust starting x based on actual number of documents created.
 - Data/control flow through changed code
 - Dependencies between changed files
 - Trust boundaries (for security-relevant changes)
+- Where a node corresponds to a single source file, append its URL on a second line of the label so a reader can copy it (paths only — diagram nodes are not clickable). Skip the URL when no remote is available.
 
 ### 6. Post link back to PR/MR
 
@@ -369,10 +451,12 @@ If editing the description fails because the user lacks permission (for example,
 
 ## Output
 
-After completion, provide:
+If the §4.5 bail-out applied, the entire output is the trivial-PR chat message — no board link, no description update, nothing else.
+
+Otherwise, after completion provide:
 1. Link to the Miro board (or frame, if `moveToWidget` was provided)
 2. Confirmation that the PR/MR description was updated, or that we left a comment as a fallback, or that the post step was skipped because the source was local / branchless
-3. Summary of elements created (X docs, Y diagrams, Z table rows)
+3. Summary of elements created (X docs, Y diagrams, Z table rows) — and which artifact types were intentionally skipped per §4.5, with a one-line reason
 4. High-risk files requiring careful review
 5. Security findings (if any critical/high)
 6. Architecture concerns (if any breaking changes)

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "miro",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Secure access to Miro boards. Enables AI to read board context, create diagrams, and generate code with enterprise-grade security.",
   "mcpServers": {
     "miro": {

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "miro",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "description": "Secure access to Miro boards. Enables AI to read board context, create diagrams, and generate code with enterprise-grade security.",
   "mcpServers": {
     "miro": {

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "miro",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Secure access to Miro boards. Enables AI to read board context, create diagrams, and generate code with enterprise-grade security.",
   "mcpServers": {
     "miro": {

--- a/skills/miro-code-review/SKILL.md
+++ b/skills/miro-code-review/SKILL.md
@@ -103,6 +103,32 @@ LINK_SHA=$(git rev-parse HEAD)
 
 REST fallback: read `head.sha` (GitHub) or `diff_refs.head_sha` (GitLab) from the same JSON payload already fetched above — no extra round-trip needed.
 
+- `LINK_BASE_SHA` — base commit SHA (the PR/MR target tip, or the merge-base for branch comparisons). Required by §5 "Showing change" to render before/after diagrams and to hyperlink "before" nodes to the prior revision:
+
+```bash
+# GitHub
+LINK_BASE_SHA=$(gh pr view $PR_NUMBER --json baseRefOid -q .baseRefOid)
+# external repo: add --repo $OWNER/$REPO
+
+# GitLab
+LINK_BASE_SHA=$(glab mr view $MR_NUMBER -F json | jq -r '.diff_refs.base_sha // .target_branch')
+# external project: add -R $GROUP/$PROJECT
+
+# Local diff (uncommitted): base is the current HEAD itself
+LINK_BASE_SHA=$(git rev-parse HEAD)
+
+# Branch comparison
+LINK_BASE_SHA=$(git merge-base origin/$DEFAULT_BRANCH HEAD)
+```
+
+To extract the pre-change content of a single file (needed when the unified diff alone doesn't carry enough surrounding structure, e.g. class hierarchies):
+
+```bash
+git show $LINK_BASE_SHA:path/to/file
+```
+
+If the base SHA is unreachable (shallow clone, history pruned, target branch not fetched), skip "before" diagrams and announce once in chat: `"base revision unavailable — only 'after' diagrams created"`.
+
 - `LINK_TEMPLATE` — pick by host shape; substitute `{path}` per reference, append `#L<start>-L<end>` line anchors when calling out a specific hunk:
   - GitHub-style: `https://{host}/{owner}/{repo}/blob/{sha}/{path}` (anchor: `#L{a}-L{b}`)
   - GitLab-style: `https://{host}/{group}/{project}/-/blob/{sha}/{path}` (anchor: `#L{a}-{b}`)
@@ -167,7 +193,7 @@ Skip §5 and §6 entirely.
 - **Summary doc** — create when the PR has non-trivial intent that isn't already captured in the PR title/body, OR when ≥ 2 high-risk items need callouts. Skip if it would just paraphrase the PR description.
 - **Architecture doc** — create only if structural changes are detected (new modules, modified public interfaces, dependency changes, breaking changes). Skip otherwise.
 - **Security doc** — create only when security-sensitive paths are touched (see §3 "Security Analysis"). Never create as a checklist-only artifact.
-- **Diagram** — create only when the change involves multi-component flow, control/data path changes, or structural relationships that are hard to grasp from the diff. Explicitly skip diagrams that would be a single node, two nodes with one arrow, or a literal restatement of the diff.
+- **Diagram** — create only when the change involves multi-component flow, control/data path changes, or structural relationships that are hard to grasp from the diff. Render as a **side-by-side before/after pair** by default (see §5 "Showing change"); use a **single annotated "after" diagram** only when the change is purely additive and touches ≤ 3 elements. Explicitly skip diagrams that would be a single node, two nodes with one arrow, or a literal restatement of the diff.
 
 **Announce the plan in chat** before creating anything, e.g.:
 
@@ -217,6 +243,8 @@ Use a **horizontal row layout** because tables and docs have fixed width but var
 | Medium | 6–15 | < 500 | 1–2 (summary + deep-dive if needed) | 1–3 |
 | Large | 16–30 | < 1500 | 2–3 (summary + architecture + security if applicable) | 2–4 |
 | Very Large | 30+ | ≥ 1500 | 3+ (by subsystem) | 3+ |
+
+> A side-by-side before/after pair counts as **one** diagram for the budgets above — the column limits conceptual artifacts, not raw board widgets.
 
 ---
 
@@ -357,37 +385,80 @@ For Very Large PRs, create per-subsystem documents (continue incrementing x by 8
 
 Create diagrams based on the type of changes. Position after the last document (continue x increments of 800).
 
+##### Showing change: before/after vs. annotated
+
+Every diagram must make the *delta* visible at a glance, not just the post-change state.
+
+- **Default: side-by-side before/after pair.** Build two diagrams of the same type with the same DSL conventions and place them adjacently on the same y-row. Build the "before" from the `LINK_BASE_SHA` revision (use `git show $LINK_BASE_SHA:path` when the unified diff doesn't carry enough surrounding structure), and the "after" from `LINK_SHA`.
+- **Single annotated "after" diagram instead** when *all* of these hold:
+  - The change is purely additive (no deleted files, no removed classes/components, no removed edges in the relevant subsystem), AND
+  - The additions do not rearrange existing relationships (no rewired callers, no moved responsibilities), AND
+  - There are ≤ 3 new nodes/edges to mark.
+- If `LINK_BASE_SHA` is unreachable (shallow clone, history pruned), degrade every pair to a single annotated "after" diagram and reuse the chat announcement from §2.
+
+##### Marking convention
+
+Primary signal is the **label prefix**, because per-element styling is not guaranteed by the Miro Mermaid renderer:
+
+- `[ADDED] <name>` — element introduced in this change. In an *after* diagram only (omitted from before).
+- `[REMOVED] <name>` — element deleted in this change. In a *before* diagram only (omitted from after).
+- `[MOD] <name>` — element kept but with a meaningful change to signature, body, or relationships. Present in both diagrams; prefix appears in the *after* only.
+- Unmarked elements are unchanged context.
+
+Also emit Mermaid `classDef` directives as a best-effort visual layer — a renderer that honours them produces colour:
+
+```mermaid
+classDef added    fill:#dcfce7,stroke:#16a34a,stroke-width:2px;
+classDef removed  fill:#fee2e2,stroke:#dc2626,stroke-width:2px,stroke-dasharray:5 5;
+classDef modified fill:#fef3c7,stroke:#d97706,stroke-width:2px;
+class A,B added
+class C removed
+class D modified
+```
+
+Prefixes alone must be self-sufficient: if Miro drops the classDef block, the reviewer still sees what changed from the label text.
+
+##### Legend
+
+After the first diagram (or pair) on the board, place a small text/sticky:
+
+> Legend: `[ADDED]` new in this change · `[REMOVED]` deleted · `[MOD]` modified · unmarked = unchanged context
+
+One legend per code-review board is enough.
+
 **Diagram Selection Guide:**
 
-| Change Type | Diagram Type | Purpose |
-|-------------|--------------|---------|
-| Feature addition | `flowchart` | Show component interactions |
-| Refactoring | `uml_class` | Show structural changes |
-| API/integration | `uml_sequence` | Show interaction flow |
-| Database changes | `entity_relationship` | Show schema modifications |
-| Bug fix | `flowchart` | Show fix location in flow |
-| Data pipeline | `flowchart` | Show data flow |
+| Change Type | Diagram Type | Pattern | Purpose |
+|-------------|--------------|---------|---------|
+| Feature addition (purely additive) | `flowchart` | Single annotated (after) | Show new components and how they wire in |
+| Refactoring | `uml_class` | Side-by-side before/after | Structural rearrangement is the whole point |
+| API/integration change | `uml_sequence` | Side-by-side before/after | Flow shape changes |
+| DB migration / schema change | `entity_relationship` | Side-by-side before/after | Schema delta is the focus |
+| Bug fix | `flowchart` | Single annotated (after) | Mark the fix point in the flow |
+| Data pipeline restructure | `flowchart` | Side-by-side before/after | Data flow shape changes |
+| Mixed / large refactor | per-subsystem | Side-by-side per subsystem | One pair per affected boundary |
 
 **Diagram Positions:**
 
-Position diagrams after the last document. For a typical Large PR with 3 docs:
+A side-by-side pair occupies two adjacent x slots (gap = 2000 between pair members); the next diagram or pair starts another 2000 after the last slot used. A single annotated diagram occupies one slot. Let `N` = last document `x` + 800.
 
-| Diagram | Position | When to Create |
-|---------|----------|----------------|
-| Main flow/architecture | x=3200, y=0 | Always |
-| Component relationships | x=4000, y=0 | Medium+ PRs |
-| Sequence/interaction | x=4800, y=0 | API changes |
-| Data flow | x=5600, y=0 | Data pipeline changes |
-| Before/after comparison | x=6400, y=0 | Major refactoring |
+| Diagram (or pair) | Position(s) | When to create |
+|-------------------|-------------|----------------|
+| Main flow/architecture pair | `before` at x=N, `after` at x=N+2000 | Always |
+| Component relationships pair | next two slots | Medium+ PRs with structural change |
+| Sequence/interaction pair | next two slots | API/integration changes |
+| ER pair | next two slots | Data pipeline / schema changes |
+| Single annotated (additions only) | one slot | Purely additive change, ≤ 3 new elements |
 
-Adjust starting x based on actual number of documents created.
+Adjust `N` based on the actual number of documents created.
 
 **Each diagram should show:**
 - Affected components/modules (highlighted)
 - Data/control flow through changed code
 - Dependencies between changed files
 - Trust boundaries (for security-relevant changes)
-- Where a node corresponds to a single source file, append its URL on a second line of the label so a reader can copy it (paths only — diagram nodes are not clickable). Skip the URL when no remote is available.
+- Where a node corresponds to a single source file, append its URL on a second line of the label so a reader can copy it (paths only — diagram nodes are not clickable). Skip the URL when no remote is available. Use `LINK_BASE_SHA` in URLs on *before* diagrams; use `LINK_SHA` on *after* diagrams.
+- The change markers from §5 "Marking convention" applied to every modified/added/removed element — the diagram or pair must make the delta visible at a glance.
 
 ### 6. Post link back to PR/MR
 
@@ -456,7 +527,7 @@ If the §4.5 bail-out applied, the entire output is the trivial-PR chat message 
 Otherwise, after completion provide:
 1. Link to the Miro board (or frame, if `moveToWidget` was provided)
 2. Confirmation that the PR/MR description was updated, or that we left a comment as a fallback, or that the post step was skipped because the source was local / branchless
-3. Summary of elements created (X docs, Y diagrams, Z table rows) — and which artifact types were intentionally skipped per §4.5, with a one-line reason
+3. Summary of elements created (X docs, Y diagrams as N pairs + M single annotated, Z table rows) — base revision `<short LINK_BASE_SHA>`, head revision `<short LINK_SHA>` — and which artifact types were intentionally skipped per §4.5, with a one-line reason
 4. High-risk files requiring careful review
 5. Security findings (if any critical/high)
 6. Architecture concerns (if any breaking changes)

--- a/skills/miro-code-review/SKILL.md
+++ b/skills/miro-code-review/SKILL.md
@@ -402,7 +402,7 @@ Primary signal is the **label prefix**, because per-element styling is not guara
 
 - `[ADDED] <name>` — element introduced in this change. In an *after* diagram only (omitted from before).
 - `[REMOVED] <name>` — element deleted in this change. In a *before* diagram only (omitted from after).
-- `[MOD] <name>` — element kept but with a meaningful change to signature, body, or relationships. Present in both diagrams; prefix appears in the *after* only.
+- `[UPDATED] <name>` — element kept but with a meaningful change to signature, body, or relationships. Present in both diagrams; prefix appears in the *after* only.
 - Unmarked elements are unchanged context.
 
 Also emit Mermaid `classDef` directives as a best-effort visual layer — a renderer that honours them produces colour:
@@ -410,21 +410,13 @@ Also emit Mermaid `classDef` directives as a best-effort visual layer — a rend
 ```mermaid
 classDef added    fill:#dcfce7,stroke:#16a34a,stroke-width:2px;
 classDef removed  fill:#fee2e2,stroke:#dc2626,stroke-width:2px,stroke-dasharray:5 5;
-classDef modified fill:#fef3c7,stroke:#d97706,stroke-width:2px;
+classDef updated  fill:#fef3c7,stroke:#d97706,stroke-width:2px;
 class A,B added
 class C removed
-class D modified
+class D updated
 ```
 
-Prefixes alone must be self-sufficient: if Miro drops the classDef block, the reviewer still sees what changed from the label text.
-
-##### Legend
-
-After the first diagram (or pair) on the board, place a small text/sticky:
-
-> Legend: `[ADDED]` new in this change · `[REMOVED]` deleted · `[MOD]` modified · unmarked = unchanged context
-
-One legend per code-review board is enough.
+Prefixes alone must be self-sufficient: if Miro drops the classDef block, the reviewer still sees what changed from the label text. Do not create a legend widget on the board — the prefixes are self-explanatory and a separate legend just clutters the layout.
 
 **Diagram Selection Guide:**
 
@@ -527,7 +519,7 @@ If the §4.5 bail-out applied, the entire output is the trivial-PR chat message 
 Otherwise, after completion provide:
 1. Link to the Miro board (or frame, if `moveToWidget` was provided)
 2. Confirmation that the PR/MR description was updated, or that we left a comment as a fallback, or that the post step was skipped because the source was local / branchless
-3. Summary of elements created (X docs, Y diagrams as N pairs + M single annotated, Z table rows) — base revision `<short LINK_BASE_SHA>`, head revision `<short LINK_SHA>` — and which artifact types were intentionally skipped per §4.5, with a one-line reason
+3. Summary of elements created (X docs, Y diagrams as N pairs + M single annotated, Z table rows). Mention base revision `<short LINK_BASE_SHA>` and head revision `<short LINK_SHA>` in this chat summary only — do **not** place these SHAs on the Miro board. Also note which artifact types were intentionally skipped per §4.5, with a one-line reason.
 4. High-risk files requiring careful review
 5. Security findings (if any critical/high)
 6. Architecture concerns (if any breaking changes)

--- a/skills/miro-code-review/SKILL.md
+++ b/skills/miro-code-review/SKILL.md
@@ -78,6 +78,40 @@ git log $DEFAULT_BRANCH..HEAD --oneline
 git diff $DEFAULT_BRANCH...HEAD
 ```
 
+#### Determine the source-link base URL
+
+Capture once and reuse for every file reference in §5 (table cells, document bullets, diagram labels). Pin links to the head SHA so they survive force-pushes.
+
+Record:
+
+- `LINK_HOST` — host from §1 (e.g. `github.com`, `gitlab.com`, self-hosted)
+- `LINK_OWNER` / `LINK_REPO` (GitHub-style) **or** `LINK_GROUP` / `LINK_PROJECT` (GitLab-style)
+- `LINK_SHA` — PR/MR head commit SHA, fetched per platform:
+
+```bash
+# GitHub
+LINK_SHA=$(gh pr view $PR_NUMBER --json headRefOid -q .headRefOid)
+# external repo: add --repo $OWNER/$REPO
+
+# GitLab
+LINK_SHA=$(glab mr view $MR_NUMBER -F json | jq -r '.diff_refs.head_sha // .sha')
+# external project: add -R $GROUP/$PROJECT
+
+# Local diff or branch comparison
+LINK_SHA=$(git rev-parse HEAD)
+```
+
+REST fallback: read `head.sha` (GitHub) or `diff_refs.head_sha` (GitLab) from the same JSON payload already fetched above — no extra round-trip needed.
+
+- `LINK_TEMPLATE` — pick by host shape; substitute `{path}` per reference, append `#L<start>-L<end>` line anchors when calling out a specific hunk:
+  - GitHub-style: `https://{host}/{owner}/{repo}/blob/{sha}/{path}` (anchor: `#L{a}-L{b}`)
+  - GitLab-style: `https://{host}/{group}/{project}/-/blob/{sha}/{path}` (anchor: `#L{a}-{b}`)
+  - Bitbucket-style (example pattern, not exhaustive): `https://{host}/{workspace}/{repo}/src/{sha}/{path}`
+
+**No-remote sources** (`local changes`, or a branch with no pushed remote / no PR): set `LINK_TEMPLATE=""` and announce in chat once: `"No remote URL available — file references shown as plain paths."` Do not invent URLs.
+
+State the chosen template in chat before creating artifacts, e.g.: `Source links: https://github.com/acme/api/blob/<sha>/{path}`.
+
 ### 3. Analyze Changes
 
 For each changed file, determine:
@@ -110,9 +144,55 @@ For each changed file, determine:
 | **Medium** | API changes, configuration, shared utilities, new dependencies, data model changes |
 | **Low** | Tests, documentation, styling, localization, internal refactoring |
 
+### 4.5 Triage: decide what (if anything) to create
+
+Every artifact must earn its place. Before doing any creation work, decide whether the PR is worth visualizing at all and which artifact types would actually help a reviewer.
+
+**Bail-out rule.** If **all** of the following hold, create no Miro artifacts and report only in chat:
+
+- ≤ 2 files changed, AND
+- < 20 lines changed (additions + deletions combined), AND
+- No file marked **High** risk in §4, AND
+- No security-sensitive paths touched (auth, crypto, config, migrations).
+
+In that case, the entire skill output is a single chat message of the form:
+
+> PR is trivial (N files, ±M lines, no high-risk areas). Skipping Miro visualization — a board would not add review value. PR/MR description was not modified.
+
+Skip §5 and §6 entirely.
+
+**Value gate (per artifact).** When the bail-out does not apply, still only create an artifact if it tells a reviewer something the diff itself does not already make obvious:
+
+- **Table** — create when ≥ 3 files changed *or* mixed risk levels exist. For 1–2 file PRs that don't bail out, skip the table.
+- **Summary doc** — create when the PR has non-trivial intent that isn't already captured in the PR title/body, OR when ≥ 2 high-risk items need callouts. Skip if it would just paraphrase the PR description.
+- **Architecture doc** — create only if structural changes are detected (new modules, modified public interfaces, dependency changes, breaking changes). Skip otherwise.
+- **Security doc** — create only when security-sensitive paths are touched (see §3 "Security Analysis"). Never create as a checklist-only artifact.
+- **Diagram** — create only when the change involves multi-component flow, control/data path changes, or structural relationships that are hard to grasp from the diff. Explicitly skip diagrams that would be a single node, two nodes with one arrow, or a literal restatement of the diff.
+
+**Announce the plan in chat** before creating anything, e.g.:
+
+> Plan: 1 table, 1 summary doc, no diagrams (changes are localized to a single function).
+
+This makes the triage visible and lets the user redirect before any board content is created.
+
 ### 5. Create Miro Board Content
 
-**IMPORTANT: Scale content based on PR size.** Create multiple documents and diagrams for larger PRs.
+**Principle:** every artifact must earn its place. If an artifact would not help a reviewer understand the PR faster than the diff alone, do not create it. See §4.5 for the triage rules.
+
+**Scale content *up to* these caps based on PR size, and apply the §4.5 value gates — fewer artifacts is fine.**
+
+#### Linking conventions
+
+Every file reference produced in §5 must be a clickable hyperlink to the source platform when a base URL is available. Use the `LINK_TEMPLATE` and `LINK_SHA` captured in §2.
+
+- **When `LINK_TEMPLATE` is set** (PR/MR or branch with a known remote): build the URL by substituting the file `{path}`. Add a line anchor `#L<start>-L<end>` when calling out a specific hunk (high-risk files, security findings, architecture callouts). Resolve start/end from the diff hunks captured in §2 (`@@ -a,b +c,d @@`, use the new-file range). Skip the anchor if the reference spans multiple non-contiguous hunks.
+- **When `LINK_TEMPLATE` is empty** (`local changes` or no remote): render every file reference as a plain path. Do not invent URLs.
+
+Per-artifact rules:
+
+- **Table → File column**: put the full URL as the cell content. Miro renders URLs in text cells as clickable links. With no remote, put the plain path.
+- **Documents**: use markdown links — `[path/to/file.ts](url)` for whole-file references and `[path/to/file.ts:42-58](url#L42-L58)` for hunk references. Apply this in *every* file mention (Overview, Key Changes, High-Risk Areas, Architecture > New Components / Modified Interfaces, Security > Security-Sensitive Changes, etc.).
+- **Diagrams**: keep node labels as plain paths — the Miro diagram tool does not document clickable nodes. When a node corresponds to a single source file, append the URL as a second line in the node label so a reader can copy it.
 
 **Positioning Notes:**
 
@@ -130,12 +210,13 @@ Use a **horizontal row layout** because tables and docs have fixed width but var
 
 #### Scaling Guidelines
 
-| PR Size | Files | Documents | Diagrams |
-|---------|-------|-----------|----------|
-| Small | 1-5 | 1 summary | 1 flow diagram |
-| Medium | 6-15 | 2 docs (summary + deep-dive) | 2-3 diagrams |
-| Large | 16-30 | 3 docs (summary + architecture + security) | 3-4 diagrams |
-| Very Large | 30+ | 4+ docs (by subsystem/area) | 5+ diagrams |
+| PR Size | Files | LOC (±) | Documents | Diagrams |
+|---------|-------|---------|-----------|----------|
+| Trivial | 1–2 | < 20 | none (bail out per §4.5) | none |
+| Small | 1–5 | < 100 | 0–1 summary | 0–1 flow |
+| Medium | 6–15 | < 500 | 1–2 (summary + deep-dive if needed) | 1–3 |
+| Large | 16–30 | < 1500 | 2–3 (summary + architecture + security if applicable) | 2–4 |
+| Very Large | 30+ | ≥ 1500 | 3+ (by subsystem) | 3+ |
 
 ---
 
@@ -146,7 +227,7 @@ Create first (appears at board center). Use Miro MCP tool to create a table with
 | Column | Type | Options |
 |--------|------|---------|
 | Status | select | Added (#00FF00), Modified (#FFA500), Deleted (#FF0000) |
-| File | text | File path |
+| File | text | Linked file URL (Miro auto-renders URLs in text cells as clickable). Use the plain path when no remote URL is available — see §5 "Linking conventions". |
 | Change | text | Brief summary of changes and key review points |
 | Risk | select | Low (#00FF00), Medium (#FFA500), High (#FF0000) |
 
@@ -160,7 +241,7 @@ For very large PRs (30+ files), create separate tables:
 
 **Document 1: Main Summary (x=800, y=0)**
 
-Always create this document:
+Create when the §4.5 value gate for the summary doc passes. Skip if the PR description already covers the same ground.
 
 ```markdown
 # Code Review: [PR Title]
@@ -178,7 +259,7 @@ Always create this document:
 - [Bullet points of significant changes]
 
 ## High-Risk Areas
-- [Files/components requiring careful review]
+- [path/to/file.ts:42-58](url#L42-L58) — [reason this file is high-risk]
 
 ## Review Checklist
 - [ ] Logic correctness verified
@@ -193,7 +274,7 @@ Always create this document:
 
 **Document 2: Architecture Analysis (x=1600, y=0)**
 
-Create for Medium+ PRs or when structural changes detected:
+Create only when the §4.5 architecture-doc value gate passes — i.e. the diff introduces new modules, modifies public interfaces, changes dependencies, or adds breaking changes. Skip otherwise, even on Medium/Large PRs.
 
 ```markdown
 # Architecture Analysis
@@ -201,13 +282,13 @@ Create for Medium+ PRs or when structural changes detected:
 ## Structural Changes
 
 ### New Components
-- [List new modules, services, classes]
+- [path/to/new_module.ts](url) — [purpose / role]
 
 ### Modified Interfaces
-- [API changes, contract modifications]
+- [path/to/api.ts:120-180](url#L120-L180) — [API change / contract modification]
 
 ### Dependency Changes
-- [New, removed, or updated dependencies]
+- [package.json](url) — [added/removed/updated dependency]
 
 ## Design Patterns
 - [Patterns introduced or modified]
@@ -225,7 +306,7 @@ Create for Medium+ PRs or when structural changes detected:
 
 **Document 3: Security Analysis (x=2400, y=0)**
 
-Create for Large+ PRs or when security-sensitive code detected:
+Create only when security-sensitive paths are touched (auth, crypto, config, migrations, input handling). Never create as a checklist-only artifact on a PR with no security-relevant diff.
 
 ```markdown
 # Security Analysis
@@ -233,9 +314,9 @@ Create for Large+ PRs or when security-sensitive code detected:
 **Risk Score:** [Critical/High/Medium/Low]
 
 ## Security-Sensitive Changes
-- [Auth/authz modifications]
-- [Data handling changes]
-- [API exposure changes]
+- [path/to/auth.ts:30-95](url#L30-L95) — [auth/authz modification]
+- [path/to/handler.ts:10-40](url#L10-L40) — [data handling change]
+- [path/to/route.ts:200-220](url#L200-L220) — [API exposure change]
 
 ## Vulnerability Assessment
 
@@ -306,6 +387,7 @@ Adjust starting x based on actual number of documents created.
 - Data/control flow through changed code
 - Dependencies between changed files
 - Trust boundaries (for security-relevant changes)
+- Where a node corresponds to a single source file, append its URL on a second line of the label so a reader can copy it (paths only — diagram nodes are not clickable). Skip the URL when no remote is available.
 
 ### 6. Post link back to PR/MR
 
@@ -369,10 +451,12 @@ If editing the description fails because the user lacks permission (for example,
 
 ## Output
 
-After completion, provide:
+If the §4.5 bail-out applied, the entire output is the trivial-PR chat message — no board link, no description update, nothing else.
+
+Otherwise, after completion provide:
 1. Link to the Miro board (or frame, if `moveToWidget` was provided)
 2. Confirmation that the PR/MR description was updated, or that we left a comment as a fallback, or that the post step was skipped because the source was local / branchless
-3. Summary of elements created (X docs, Y diagrams, Z table rows)
+3. Summary of elements created (X docs, Y diagrams, Z table rows) — and which artifact types were intentionally skipped per §4.5, with a one-line reason
 4. High-risk files requiring careful review
 5. Security findings (if any critical/high)
 6. Architecture concerns (if any breaking changes)


### PR DESCRIPTION
## Summary
- **Triage gate** in `miro-code-review`: bail out with a chat-only report on trivial PRs (≤2 files, <20 LOC, no high-risk/security paths). Per-artifact value gates discourage docs/diagrams that would just paraphrase the diff. Scaling table gains a "Trivial" tier and is reframed as upper bounds.
- **Hyperlinked file references**: §2 now captures the PR/MR head SHA (`gh pr view --json headRefOid`, `glab mr view -F json | jq .diff_refs.head_sha`, or `git rev-parse HEAD`) and builds a `LINK_TEMPLATE` per platform (GitHub `blob`, GitLab `-/blob`, Bitbucket `src`). Table File cells hold full URLs, doc bullets use markdown links with `#L<a>-L<b>` anchors derived from diff hunks, diagram nodes append the URL on a second label line. Falls back to plain paths for `local changes` / no-remote sources.
- Plugin bumped to `1.2.2`; auto-generated mirrors (`skills/`, `codex-plugins/`, `cursor-plugins/`, `copilot-cowork-plugins/`, `gemini-extension.json`) regenerated via `bun run convert`.

## Test plan
- [ ] `bun run validate` passes locally (already confirmed).
- [ ] Run skill on a **trivial** GitHub PR (e.g. 1-line typo) — verify it announces the bail-out, creates no Miro artifacts, and leaves the PR description untouched.
- [ ] Run skill on a **medium** GitHub PR — verify table File cells contain `https://github.com/<owner>/<repo>/blob/<sha>/<path>` URLs that resolve, summary doc bullets are markdown-linked with `#L<a>-L<b>` anchors, and links survive a follow-up push (SHA-pinned).
- [ ] Run skill on a **GitLab MR** — verify `/-/blob/<sha>/<path>` URLs render and resolve.
- [ ] Run skill against `local changes` — verify chat states "no remote URL available", artifacts show plain paths, no broken links.
- [ ] Open the resulting Miro board — confirm table URLs are clickable, doc links open the correct file/line range, diagram node labels show path + URL on two lines.

<!-- miro-pr-docs:start -->
## PR documentation

PR details on Miro: https://miro.com/app/board/uXjVG1gkSxE=/

- 2 documents, 1 diagram, 11 table rows
- High-risk files: 0
- Security findings: 0
<!-- miro-pr-docs:end -->
